### PR TITLE
Optimization: Keepalive packet for mouse

### DIFF
--- a/Core/MousePlayer.cs
+++ b/Core/MousePlayer.cs
@@ -89,11 +89,20 @@ namespace AmuletOfManyMinions.Core
 				{
 					//If hasn't sent a mouse position recently, or when an update is required
 
+					//Send packet
+					if (NextMousePosition != Main.MouseWorld)
+					{
+						new MousePacket(player, Main.MouseWorld).Send();
+					}
+					else
+					{
+						//If mouse position didn't change, reset timeout and send a packet that does the same
+						ResetTimeout();
+						new MouseResetTimeoutPacket(player).Send();
+					}
+
 					//Required so client also updates this variable even though its not used directly
 					NextMousePosition = Main.MouseWorld;
-
-					//Send packet
-					new MousePacket(player, Main.MouseWorld).Send();
 				}
 			}
 		}
@@ -107,6 +116,14 @@ namespace AmuletOfManyMinions.Core
 			{
 				NextMousePosition = position;
 			}
+		}
+
+		/// <summary>
+		/// Called on receiving latest keepalive packet by server or other clients
+		/// </summary>
+		public void ResetTimeout()
+		{
+			timeoutTimer = 0;
 		}
 
 		/// <summary>

--- a/Core/Netcode/Packets/MouseResetTimeoutPacket.cs
+++ b/Core/Netcode/Packets/MouseResetTimeoutPacket.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Xna.Framework;
+using System.IO;
+using Terraria;
+using Terraria.ID;
+
+namespace AmuletOfManyMinions.Core.Netcode.Packets
+{
+	public class MouseResetTimeoutPacket : PlayerPacket
+	{
+		//For reflection
+		public MouseResetTimeoutPacket() { }
+
+		public MouseResetTimeoutPacket(Player player) : base(player)
+		{
+
+		}
+
+		protected override void PostReceive(BinaryReader reader, int sender, Player player)
+		{
+			player.GetModPlayer<MousePlayer>().ResetTimeout();
+
+			if (Main.netMode == NetmodeID.Server)
+			{
+				new MouseResetTimeoutPacket(player).Send(from: sender, bcCondition: delegate (Player otherPlayer)
+				{
+					//Only send to other player if he's in visible range
+					Rectangle bounds = Utils.CenteredRectangle(player.Center, new Vector2(1920, 1080) * 1.5f);
+					Point otherPlayerCenter = otherPlayer.Center.ToPoint();
+					return bounds.Contains(otherPlayerCenter);
+				});
+			}
+		}
+
+		protected override void PostSend(BinaryWriter writer, Player player)
+		{
+			//Nothing
+		}
+	}
+}

--- a/Core/Netcode/Packets/SyncMinionTacticsPlayerPacket.cs
+++ b/Core/Netcode/Packets/SyncMinionTacticsPlayerPacket.cs
@@ -29,8 +29,9 @@ namespace AmuletOfManyMinions.Core.Netcode.Packets
 			byte id = reader.ReadByte();
 			byte ignoreTargetReticle = reader.ReadByte();
 
-			player.GetModPlayer<MinionTacticsPlayer>().SetTactic(id, fromSync: true);
-			player.GetModPlayer<MinionTacticsPlayer>().IgnoreVanillaMinionTarget = ignoreTargetReticle;
+			MinionTacticsPlayer minionTacticsPlayer = player.GetModPlayer<MinionTacticsPlayer>();
+			minionTacticsPlayer.SetTactic(id, fromSync: true);
+			minionTacticsPlayer.IgnoreVanillaMinionTarget = ignoreTargetReticle;
 		}
 	}
 }


### PR DESCRIPTION
Adds a keepalive packet that refreshes the timeout for when no new mouse position exists (client keeps mouse in the same position). This saves sending 4 additional bytes with the position info.