### PR TITLE
[1.4] Make worm minion damage hitboxes four times as big area wise

### DIFF
--- a/Projectiles/Minions/MinonBaseClasses/WormMinion.cs
+++ b/Projectiles/Minions/MinonBaseClasses/WormMinion.cs
@@ -36,6 +36,12 @@ namespace AmuletOfManyMinions.Projectiles.Minions.MinonBaseClasses
 			Projectile.height = 8;
 		}
 
+		public override void ModifyDamageHitbox(ref Rectangle hitbox)
+		{
+			// make damage hitboxes four times as big area wise (e.g. 2x2 into 4x4)
+			hitbox.Inflate(Projectile.width / 2, Projectile.height / 2);
+		}
+
 		public override bool PreDraw(ref Color lightColor)
 		{
 			wormDrawer.Draw(Terraria.GameContent.TextureAssets.Projectile[Projectile.type], lightColor);

--- a/Projectiles/Minions/SimpleMinion.cs
+++ b/Projectiles/Minions/SimpleMinion.cs
@@ -251,7 +251,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions
 		// utility methods
 		public void TeleportToPlayer(ref Vector2 vectorToIdlePosition, float maxDistance)
 		{
-			if (Main.myPlayer == player.whoAmI && vectorToIdlePosition.Length() > maxDistance)
+			if (Main.myPlayer == player.whoAmI && vectorToIdlePosition.LengthSquared() > maxDistance * maxDistance)
 			{
 				Projectile.position += vectorToIdlePosition;
 				Projectile.velocity = Vector2.Zero;


### PR DESCRIPTION
Title. Also optimizes a common Length() check