### PR TITLE
Add Summoner's Shine stat compatibility to Combat Pet Emblems

### DIFF
--- a/Core/Netcode/Packets/CombatPetLevelModdedPacket.cs
+++ b/Core/Netcode/Packets/CombatPetLevelModdedPacket.cs
@@ -1,0 +1,45 @@
+using AmuletOfManyMinions.Projectiles.Minions.CombatPets;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using Terraria.ID;
+
+namespace AmuletOfManyMinions.Core.Netcode.Packets
+{
+	class CombatPetLevelModdedPacket : PlayerPacket
+	{
+		readonly object[] petModdedData;
+		readonly int petEmblemItem;
+
+		public CombatPetLevelModdedPacket() { }
+
+		public CombatPetLevelModdedPacket(Player player, int petEmblemItem, object[] petModdedData) : base(player)
+		{
+			this.petModdedData = petModdedData;
+			this.petEmblemItem = petEmblemItem;
+		}
+
+		protected override void PostSend(BinaryWriter writer, Player player)
+		{
+			writer.Write7BitEncodedInt(petEmblemItem);
+			CrossMod.CombatPetSendCrossModData(writer, petModdedData);
+		}
+
+		protected override void PostReceive(BinaryReader reader, int sender, Player player)
+		{
+			int petEmblemItem = reader.Read7BitEncodedInt();
+			object[] petModdedStats = CrossMod.CombatPetReceiveCrossModData(reader);
+      
+			LeveledCombatPetModPlayer modPlayer = player.GetModPlayer<LeveledCombatPetModPlayer>();
+			modPlayer.UpdatePetLevelModded(petEmblemItem, petModdedStats, fromSync: true);
+			if (Main.netMode == NetmodeID.Server)
+			{
+				new CombatPetLevelModdedPacket(player, petEmblemItem, petModdedStats).Send(from: sender);
+			}
+		}
+	}
+}

--- a/Core/Netcode/Packets/CombatPetLevelPacket.cs
+++ b/Core/Netcode/Packets/CombatPetLevelPacket.cs
@@ -1,4 +1,4 @@
-﻿using AmuletOfManyMinions.Projectiles.Minions.CombatPets;
+using AmuletOfManyMinions.Projectiles.Minions.CombatPets;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -15,30 +15,35 @@ namespace AmuletOfManyMinions.Core.Netcode.Packets
 		// pet level is bounded to (0, 255)
 		readonly byte petLevel;
 		readonly short petDamage;
+		readonly object[] petModdedData;
 
 		public CombatPetLevelPacket() { }
 
-		public CombatPetLevelPacket(Player player, byte petLevel, short petDamage) : base(player)
+		public CombatPetLevelPacket(Player player, byte petLevel, short petDamage, object[] petModdedData) : base(player)
 		{
 			this.petLevel = petLevel;
 			this.petDamage = petDamage;
+			this.petModdedData = petModdedData;
 		}
 
 		protected override void PostSend(BinaryWriter writer, Player player)
 		{
 			writer.Write(petLevel);
 			writer.Write(petDamage);
+			CrossMod.CombatPetSendCrossModData(writer, petModdedData);
 		}
 
 		protected override void PostReceive(BinaryReader reader, int sender, Player player)
 		{
 			byte newLevel = reader.ReadByte();
 			short petDamage = reader.ReadInt16();
+			object[] petModdedStats = CrossMod.CombatPetReceiveCrossModData(reader);
 			// there may be unintended consequences to setting damage to zero
-			player.GetModPlayer<LeveledCombatPetModPlayer>().UpdatePetLevel(newLevel, petDamage, fromSync: true);
+			LeveledCombatPetModPlayer modPlayer = player.GetModPlayer<LeveledCombatPetModPlayer>();
+			modPlayer.UpdatePetLevel(newLevel, petDamage, petModdedStats, fromSync: true);
 			if (Main.netMode == NetmodeID.Server)
 			{
-				new CombatPetLevelPacket(player, newLevel, petDamage).Send(from: sender);
+				new CombatPetLevelPacket(player, newLevel, petDamage, petModdedStats).Send(from: sender);
 			}
 		}
 	}

--- a/Core/Netcode/Packets/CombatPetLevelPacket.cs
+++ b/Core/Netcode/Packets/CombatPetLevelPacket.cs
@@ -16,20 +16,23 @@ namespace AmuletOfManyMinions.Core.Netcode.Packets
 		readonly byte petLevel;
 		readonly short petDamage;
 		readonly object[] petModdedData;
+		readonly int petEmblemItem;
 
 		public CombatPetLevelPacket() { }
 
-		public CombatPetLevelPacket(Player player, byte petLevel, short petDamage, object[] petModdedData) : base(player)
+		public CombatPetLevelPacket(Player player, byte petLevel, short petDamage, int petEmblemItem, object[] petModdedData) : base(player)
 		{
 			this.petLevel = petLevel;
 			this.petDamage = petDamage;
 			this.petModdedData = petModdedData;
+			this.petEmblemItem = petEmblemItem;
 		}
 
 		protected override void PostSend(BinaryWriter writer, Player player)
 		{
 			writer.Write(petLevel);
 			writer.Write(petDamage);
+			writer.Write7BitEncodedInt(petEmblemItem);
 			CrossMod.CombatPetSendCrossModData(writer, petModdedData);
 		}
 
@@ -37,13 +40,14 @@ namespace AmuletOfManyMinions.Core.Netcode.Packets
 		{
 			byte newLevel = reader.ReadByte();
 			short petDamage = reader.ReadInt16();
+			int petEmblemItem = reader.Read7BitEncodedInt();
 			object[] petModdedStats = CrossMod.CombatPetReceiveCrossModData(reader);
 			// there may be unintended consequences to setting damage to zero
 			LeveledCombatPetModPlayer modPlayer = player.GetModPlayer<LeveledCombatPetModPlayer>();
-			modPlayer.UpdatePetLevel(newLevel, petDamage, petModdedStats, fromSync: true);
+			modPlayer.UpdatePetLevel(newLevel, petDamage, petEmblemItem, petModdedStats, fromSync: true);
 			if (Main.netMode == NetmodeID.Server)
 			{
-				new CombatPetLevelPacket(player, newLevel, petDamage, petModdedStats).Send(from: sender);
+				new CombatPetLevelPacket(player, newLevel, petDamage, petEmblemItem, petModdedStats).Send(from: sender);
 			}
 		}
 	}

--- a/Core/Netcode/Packets/CombatPetLevelPacket.cs
+++ b/Core/Netcode/Packets/CombatPetLevelPacket.cs
@@ -1,3 +1,4 @@
+
 using AmuletOfManyMinions.Projectiles.Minions.CombatPets;
 using System;
 using System.Collections.Generic;
@@ -35,8 +36,7 @@ namespace AmuletOfManyMinions.Core.Netcode.Packets
 			byte newLevel = reader.ReadByte();
 			short petDamage = reader.ReadInt16();
 			// there may be unintended consequences to setting damage to zero
-			LeveledCombatPetModPlayer modPlayer = player.GetModPlayer<LeveledCombatPetModPlayer>();
-			modPlayer.UpdatePetLevel(newLevel, petDamage, fromSync: true);
+			player.GetModPlayer<LeveledCombatPetModPlayer>().UpdatePetLevel(newLevel, petDamage, fromSync: true);
 			if (Main.netMode == NetmodeID.Server)
 			{
 				new CombatPetLevelPacket(player, newLevel, petDamage).Send(from: sender);

--- a/Core/Netcode/Packets/CombatPetLevelPacket.cs
+++ b/Core/Netcode/Packets/CombatPetLevelPacket.cs
@@ -15,39 +15,31 @@ namespace AmuletOfManyMinions.Core.Netcode.Packets
 		// pet level is bounded to (0, 255)
 		readonly byte petLevel;
 		readonly short petDamage;
-		readonly object[] petModdedData;
-		readonly int petEmblemItem;
 
 		public CombatPetLevelPacket() { }
 
-		public CombatPetLevelPacket(Player player, byte petLevel, short petDamage, int petEmblemItem, object[] petModdedData) : base(player)
+		public CombatPetLevelPacket(Player player, byte petLevel, short petDamage) : base(player)
 		{
 			this.petLevel = petLevel;
 			this.petDamage = petDamage;
-			this.petModdedData = petModdedData;
-			this.petEmblemItem = petEmblemItem;
 		}
 
 		protected override void PostSend(BinaryWriter writer, Player player)
 		{
 			writer.Write(petLevel);
 			writer.Write(petDamage);
-			writer.Write7BitEncodedInt(petEmblemItem);
-			CrossMod.CombatPetSendCrossModData(writer, petModdedData);
 		}
 
 		protected override void PostReceive(BinaryReader reader, int sender, Player player)
 		{
 			byte newLevel = reader.ReadByte();
 			short petDamage = reader.ReadInt16();
-			int petEmblemItem = reader.Read7BitEncodedInt();
-			object[] petModdedStats = CrossMod.CombatPetReceiveCrossModData(reader);
 			// there may be unintended consequences to setting damage to zero
 			LeveledCombatPetModPlayer modPlayer = player.GetModPlayer<LeveledCombatPetModPlayer>();
-			modPlayer.UpdatePetLevel(newLevel, petDamage, petEmblemItem, petModdedStats, fromSync: true);
+			modPlayer.UpdatePetLevel(newLevel, petDamage, fromSync: true);
 			if (Main.netMode == NetmodeID.Server)
 			{
-				new CombatPetLevelPacket(player, newLevel, petDamage, petEmblemItem, petModdedStats).Send(from: sender);
+				new CombatPetLevelPacket(player, newLevel, petDamage).Send(from: sender);
 			}
 		}
 	}

--- a/Core/Netcode/Packets/CombatPetLevelPacket.cs
+++ b/Core/Netcode/Packets/CombatPetLevelPacket.cs
@@ -1,4 +1,3 @@
-
 using AmuletOfManyMinions.Projectiles.Minions.CombatPets;
 using System;
 using System.Collections.Generic;

--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -370,5 +370,42 @@ namespace AmuletOfManyMinions
 			}
 			return original;
 		}
+		
+		public static Item GetPrefixComparisonItem(int netID)
+        {
+            if (Main.tooltipPrefixComparisonItem == null)
+            {
+                Main.tooltipPrefixComparisonItem = new Item();
+            }
+            Item compItem = Main.tooltipPrefixComparisonItem;
+            if (compItem.netID != netID)
+                compItem.netDefaults(netID);
+            return compItem;
+        }
+		
+		public static void GetCrossModEmblemStats(LeveledCombatPetModPlayer modPlayer, Item item)
+		{
+			Mod summonersShine = null;
+			int maxArray = 0;
+			if (ModLoader.TryGetMod("SummonersShine", out summonersShine))
+			{
+				maxArray += 3;
+			}
+			modPlayer.PerModdedStats = new object[maxArray];
+			int currentArrayPos = 0;
+			if(summonersShine != null)
+			{
+				const GET_REWORKMINION_ITEM_VALUE = 16;
+				const PREFIXMINIONPOWER = 0;
+				Item compItem = GetPrefixComparisonItem(item.netID);
+				modPlayer.PerModdedStats[currentArrayPos] = Item.useTime / compItem.useTime;
+				currentArrayPos++;
+				modPlayer.PerModdedStats[currentArrayPos] = Item.critChance;
+				currentArrayPos++;
+				
+				modPlayer.PerModdedStats[currentArrayPos] = SummonersShine.Call(GET_REWORKMINION_ITEM_VALUE, item, PREFIXMINIONPOWER);
+				currentArrayPos++;
+			}
+		}
 	}
 }

--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -392,19 +392,21 @@ namespace AmuletOfManyMinions
 			{
 				maxArray += 3;
 			}
-			modPlayer.PerModdedStats = new object[maxArray];
+			modPlayer.PetModdedStats = new object[maxArray];
 			int currentArrayPos = 0;
 			if(summonersShine != null)
 			{
 				const int GET_REWORKMINION_ITEM_VALUE = 16;
 				const int PREFIXMINIONPOWER = 0;
 				Item compItem = GetPrefixComparisonItem(item.netID);
-				modPlayer.PerModdedStats[currentArrayPos] = Item.useTime / compItem.useTime;
+				if (compItem.useTime > 0) {
+					modPlayer.PetModdedStats[currentArrayPos] = item.useTime / compItem.useTime;
+				}
 				currentArrayPos++;
-				modPlayer.PerModdedStats[currentArrayPos] = Item.critChance;
+				modPlayer.PetModdedStats[currentArrayPos] = item.crit;
 				currentArrayPos++;
 				
-				modPlayer.PerModdedStats[currentArrayPos] = summonersShine.Call(GET_REWORKMINION_ITEM_VALUE, item, PREFIXMINIONPOWER);
+				modPlayer.PetModdedStats[currentArrayPos] = summonersShine.Call(GET_REWORKMINION_ITEM_VALUE, item, PREFIXMINIONPOWER);
 				currentArrayPos++;
 			}
 		}
@@ -412,7 +414,7 @@ namespace AmuletOfManyMinions
 		public static void CombatPetComputeMinionStats(Projectile projectile, LeveledCombatPetModPlayer modPlayer)
 		{
 			int currentArrayPos = 0;
-			if (ModLoader.TryGetMod("SummonersShine", out summonersShine))
+			if (ModLoader.TryGetMod("SummonersShine", out Mod summonersShine))
 			{
 				const int SET_PROJFUNCS = 4;
 				const int SET_PROJDATA = 5;
@@ -421,11 +423,11 @@ namespace AmuletOfManyMinions
 				const int MINIONASMOD = 1;
 				const int PROJECTILECRIT = 0;
 				const int PREFIXMINIONPOWER = 10;
-				summonersShine.Call(SET_PROJFUNCS, projectile.whoAmI, MINIONASMOD, modPlayer.PerModdedStats[currentArrayPos]);
+				summonersShine.Call(SET_PROJFUNCS, projectile.whoAmI, MINIONASMOD, modPlayer.PetModdedStats[currentArrayPos]);
 				currentArrayPos++;
-				summonersShine.Call(SET_PROJFUNCS, projectile.whoAmI, PROJECTILECRIT, modPlayer.PerModdedStats[currentArrayPos]);
+				summonersShine.Call(SET_PROJFUNCS, projectile.whoAmI, PROJECTILECRIT, modPlayer.PetModdedStats[currentArrayPos]);
 				currentArrayPos++;
-				summonersShine.Call(SET_PROJDATA, projectile.whoAmI, PREFIXMINIONPOWER, modPlayer.PerModdedStats[currentArrayPos]);
+				summonersShine.Call(SET_PROJDATA, projectile.whoAmI, PREFIXMINIONPOWER, modPlayer.PetModdedStats[currentArrayPos]);
 				currentArrayPos++;
 				summonersShine.Call(USEFULFUNCS, OVERRIDESOURCEITEM, projectile, modPlayer.PetEmblemItem);
 			}

--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -410,7 +410,6 @@ namespace AmuletOfManyMinions
 		
 		public static void CombatPetComputeMinionStats(Projectile projectile, LeveledCombatPetModPlayer modPlayer)
 		{
-			int PetItemID = modPlayer.PetEmblemID;
 			int currentArrayPos = 0;
 			if (ModLoader.TryGetMod("SummonersShine", out summonersShine))
 			{
@@ -427,7 +426,7 @@ namespace AmuletOfManyMinions
 				currentArrayPos++;
 				summonersShine.Call(SET_PROJDATA, projectile.whoAmI, PREFIXMINIONPOWER, modPlayer.PerModdedStats[currentArrayPos]);
 				currentArrayPos++;
-				summonersShine.Call(USEFULFUNCS, OVERRIDESOURCEITEM, projectile, PetItemID);
+				summonersShine.Call(USEFULFUNCS, OVERRIDESOURCEITEM, projectile, modPlayer.PetEmblemItem);
 			}
 		}
 	}

--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -398,16 +398,31 @@ namespace AmuletOfManyMinions
 			{
 				const int GET_REWORKMINION_ITEM_VALUE = 16;
 				const int PREFIXMINIONPOWER = 0;
-				Item compItem = GetPrefixComparisonItem(item.netID);
-				if (compItem.useTime > 0) {
-					modPlayer.PetModdedStats[currentArrayPos] = item.useTime / (float)compItem.useTime;
+				if (item != null)
+				{
+					Item compItem = GetPrefixComparisonItem(item.netID);
+					if (compItem.useTime > 0)
+					{
+						modPlayer.PetModdedStats[currentArrayPos] = item.useTime / (float)(compItem.useTime);
+					}
+					else
+						modPlayer.PetModdedStats[currentArrayPos] = 1;
+					currentArrayPos++;
+					modPlayer.PetModdedStats[currentArrayPos] = item.crit;
+					currentArrayPos++;
+
+					modPlayer.PetModdedStats[currentArrayPos] = summonersShine.Call(GET_REWORKMINION_ITEM_VALUE, item, PREFIXMINIONPOWER);
+					currentArrayPos++;
 				}
-				currentArrayPos++;
-				modPlayer.PetModdedStats[currentArrayPos] = item.crit;
-				currentArrayPos++;
-				
-				modPlayer.PetModdedStats[currentArrayPos] = summonersShine.Call(GET_REWORKMINION_ITEM_VALUE, item, PREFIXMINIONPOWER);
-				currentArrayPos++;
+				else
+				{
+					modPlayer.PetModdedStats[currentArrayPos] = 1;
+					currentArrayPos++;
+					modPlayer.PetModdedStats[currentArrayPos] = 0;
+					currentArrayPos++;
+					modPlayer.PetModdedStats[currentArrayPos] = 0;
+					currentArrayPos++;
+				}
 			}
 		}
 		

--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -1,4 +1,5 @@
 using AmuletOfManyMinions.Projectiles.Minions;
+using AmuletOfManyMinions.Projectiles.Minions.CombatPets;
 using AmuletOfManyMinions.Projectiles.Minions.CorruptionAltar;
 using AmuletOfManyMinions.Projectiles.Minions.CrimsonAltar;
 using AmuletOfManyMinions.Projectiles.Minions.EclipseHerald;

--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -400,7 +400,7 @@ namespace AmuletOfManyMinions
 				const int PREFIXMINIONPOWER = 0;
 				Item compItem = GetPrefixComparisonItem(item.netID);
 				if (compItem.useTime > 0) {
-					modPlayer.PetModdedStats[currentArrayPos] = item.useTime / compItem.useTime;
+					modPlayer.PetModdedStats[currentArrayPos] = item.useTime / (float)compItem.useTime;
 				}
 				currentArrayPos++;
 				modPlayer.PetModdedStats[currentArrayPos] = item.crit;

--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -416,11 +416,11 @@ namespace AmuletOfManyMinions
 				}
 				else
 				{
-					modPlayer.PetModdedStats[currentArrayPos] = 1;
+					modPlayer.PetModdedStats[currentArrayPos] = 1f;
 					currentArrayPos++;
 					modPlayer.PetModdedStats[currentArrayPos] = 0;
 					currentArrayPos++;
-					modPlayer.PetModdedStats[currentArrayPos] = 0;
+					modPlayer.PetModdedStats[currentArrayPos] = 0f;
 					currentArrayPos++;
 				}
 			}

--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -395,16 +395,39 @@ namespace AmuletOfManyMinions
 			int currentArrayPos = 0;
 			if(summonersShine != null)
 			{
-				const GET_REWORKMINION_ITEM_VALUE = 16;
-				const PREFIXMINIONPOWER = 0;
+				const int GET_REWORKMINION_ITEM_VALUE = 16;
+				const int PREFIXMINIONPOWER = 0;
 				Item compItem = GetPrefixComparisonItem(item.netID);
 				modPlayer.PerModdedStats[currentArrayPos] = Item.useTime / compItem.useTime;
 				currentArrayPos++;
 				modPlayer.PerModdedStats[currentArrayPos] = Item.critChance;
 				currentArrayPos++;
 				
-				modPlayer.PerModdedStats[currentArrayPos] = SummonersShine.Call(GET_REWORKMINION_ITEM_VALUE, item, PREFIXMINIONPOWER);
+				modPlayer.PerModdedStats[currentArrayPos] = summonersShine.Call(GET_REWORKMINION_ITEM_VALUE, item, PREFIXMINIONPOWER);
 				currentArrayPos++;
+			}
+		}
+		
+		public static void CombatPetComputeMinionStats(Projectile projectile, LeveledCombatPetModPlayer modPlayer, int PetEmblemID)
+		{
+			int PetItemID = PetEmblemID;
+			int currentArrayPos = 0;
+			if (ModLoader.TryGetMod("SummonersShine", out summonersShine))
+			{
+				const int SET_PROJFUNCS = 4;
+				const int SET_PROJDATA = 5;
+				const int USEFULFUNCS = 10;
+				const int OVERRIDESOURCEITEM = 11;
+				const int MINIONASMOD = 1;
+				const int PROJECTILECRIT = 0;
+				const int PREFIXMINIONPOWER = 10;
+				summonersShine.Call(SET_PROJFUNCS, projectile.whoAmI, MINIONASMOD, modPlayer.PerModdedStats[currentArrayPos]);
+				currentArrayPos++;
+				summonersShine.Call(SET_PROJFUNCS, projectile.whoAmI, PROJECTILECRIT, modPlayer.PerModdedStats[currentArrayPos]);
+				currentArrayPos++;
+				summonersShine.Call(SET_PROJDATA, projectile.whoAmI, PREFIXMINIONPOWER, modPlayer.PerModdedStats[currentArrayPos]);
+				currentArrayPos++;
+				summonersShine.Call(USEFULFUNCS, OVERRIDESOURCEITEM, projectile, PetItemID);
 			}
 		}
 	}

--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -408,9 +408,9 @@ namespace AmuletOfManyMinions
 			}
 		}
 		
-		public static void CombatPetComputeMinionStats(Projectile projectile, LeveledCombatPetModPlayer modPlayer, int PetEmblemID)
+		public static void CombatPetComputeMinionStats(Projectile projectile, LeveledCombatPetModPlayer modPlayer)
 		{
-			int PetItemID = PetEmblemID;
+			int PetItemID = modPlayer.PetEmblemID;
 			int currentArrayPos = 0;
 			if (ModLoader.TryGetMod("SummonersShine", out summonersShine))
 			{

--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -384,6 +384,34 @@ namespace AmuletOfManyMinions
             return compItem;
         }
 		
+		public static bool GetCrossModEmblemSuperiority(Item replacer, Item old)
+		{
+			if (old == null)
+				return true;
+
+			if (ModLoader.TryGetMod("SummonersShine", out Mod summonersShine))
+			{
+				const int GET_REWORKMINION_ITEM_VALUE = 16;
+				const int PREFIXMINIONPOWER = 0;
+
+				int useTimeDiff = replacer.useTime - old.useTime;
+				if (useTimeDiff < 0)
+					return true;
+				if (useTimeDiff > 0)
+					return false;
+				int critDiff = replacer.crit - old.crit;
+				if (critDiff > 0)
+					return true;
+				if (critDiff < 0)
+					return false;
+				float apDiff = (float)summonersShine.Call(GET_REWORKMINION_ITEM_VALUE, replacer, PREFIXMINIONPOWER) - (float)summonersShine.Call(GET_REWORKMINION_ITEM_VALUE, old, PREFIXMINIONPOWER);
+				if (apDiff > 0)
+					return true;
+				if (apDiff < 0)
+					return false;
+			}
+			return false;
+		}
 		public static void GetCrossModEmblemStats(LeveledCombatPetModPlayer modPlayer, Item item)
 		{
 			Mod summonersShine = null;
@@ -406,7 +434,7 @@ namespace AmuletOfManyMinions
 						modPlayer.PetModdedStats[currentArrayPos] = item.useTime / (float)(compItem.useTime);
 					}
 					else
-						modPlayer.PetModdedStats[currentArrayPos] = 1;
+						modPlayer.PetModdedStats[currentArrayPos] = 1f;
 					currentArrayPos++;
 					modPlayer.PetModdedStats[currentArrayPos] = item.crit;
 					currentArrayPos++;

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetGroundedMinion.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetGroundedMinion.cs
@@ -39,6 +39,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets.CombatPetBaseClasse
 			Projectile.originalDamage = (int)(DamageMult * leveledPetPlayer.PetDamage);
 			int petLevel = leveledPetPlayer.PetLevel;
 			idleInertia = petLevel < 4 ? 15 : 18 - petLevel;
+			CrossMod.CombatPetComputeMinionStats(Projectile, leveledPetPlayer);
 			return base.IdleBehavior();
 		}
 
@@ -107,6 +108,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets.CombatPetBaseClasse
 		{
 			Vector2 target = base.IdleBehavior();
 			attackFrames = GetAttackFrames(leveledPetPlayer.PetLevelInfo);
+			CrossMod.CombatPetComputeMinionStats(Projectile, leveledPetPlayer);
 			return target;
 		}
 		protected override void DoGroundedMovement(Vector2 vector)

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetHoverShooterMinion.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetHoverShooterMinion.cs
@@ -54,6 +54,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets.CombatPetBaseClasse
 			Projectile.originalDamage = (int)(DamageMult * leveledPetPlayer.PetDamage);
 			UpdateHsHelperWithPetLevel(leveledPetPlayer.PetLevel);
 			dealsContactDamage = DoBumblingMovement;
+			CrossMod.CombatPetComputeMinionStats(Projectile, leveledPetPlayer);
 			return base.IdleBehavior();
 		}
 
@@ -219,6 +220,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets.CombatPetBaseClasse
 		{
 			Vector2 target = base.IdleBehavior();
 			dealsContactDamage = true;
+			CrossMod.CombatPetComputeMinionStats(Projectile, leveledPetPlayer);
 			return target;
 		}
 

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
@@ -1,4 +1,4 @@
-﻿using AmuletOfManyMinions.Core.Netcode.Packets;
+using AmuletOfManyMinions.Core.Netcode.Packets;
 using AmuletOfManyMinions.Projectiles.Minions.CombatPets.CombatPetEmblems;
 using AmuletOfManyMinions.Projectiles.Minions.VanillaClones;
 using Microsoft.Xna.Framework;
@@ -187,6 +187,21 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 			Player.maxMinions = Math.Max(0, Player.maxMinions - minionSlotsUsed);
 		}
 
+		public bool GetEmblemSuperiority(CombatPetEmblem replacer, CombatPetEmblem old)
+		{
+			int PetLevelDiff = replacer.PetLevel - old.PetLevel;
+			if (PetLevelDiff > 0)
+				return true;
+			if (PetLevelDiff < 0)
+				return false;
+			int DamageDiff = replacer.Item.damage - old.Item.damage;
+			if (DamageDiff > 0)
+				return true;
+			if (DamageDiff < 0)
+				return false;
+			return CrossMod.GetCrossModEmblemSuperiority(replacer.Item, old.Item);
+		}
+
 		// look for the best Combat Pet Emblem in the player's inventory, use that
 		// to set the player's combat pet's damage
 		private void CheckForCombatPetEmblem()
@@ -206,7 +221,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 				if(!item.IsAir && item.ModItem != null && item.ModItem is CombatPetEmblem petEmblem)
 				{
 					// choose max tier rather than max damage
-					if(petEmblem.PetLevel > maxLevel)
+					if(maxItem == null || GetEmblemSuperiority(item.ModItem as CombatPetEmblem, maxItem.ModItem as CombatPetEmblem))
 					{
 						maxLevel = petEmblem.PetLevel;
 						maxDamage = item.damage;
@@ -221,7 +236,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 				if(!item.IsAir && item.ModItem != null && item.ModItem is CombatPetEmblem petEmblem)
 				{
 					// choose max tier rather than max damage
-					if(petEmblem.PetLevel > maxLevel)
+					if (maxItem == null || GetEmblemSuperiority(item.ModItem as CombatPetEmblem, maxItem.ModItem as CombatPetEmblem))
 					{
 						maxLevel = petEmblem.PetLevel;
 						maxDamage = item.damage;

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
@@ -110,6 +110,8 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 	{
 		internal int PetLevel { get; set; }
 		internal int PetDamage { get; set; }
+		
+		public object[] PetModdedStats = null;
 
 		// todo this may be too many constructors, but it's a struct so I think it's ok
 		private PlayerCombatPetLevelInfo CustomInfo;

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
@@ -199,7 +199,8 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 			int maxLevel = 0;
 			int maxDamage = CombatPetLevelTable.PetLevelTable[0].BaseDamage;
 			Item maxItem = null;
-			for(int i = 0; i < Player.inventory.Length; i++)
+			PetEmblemItem = -1;
+			for (int i = 0; i < Player.inventory.Length; i++)
 			{
 				Item item = Player.inventory[i];
 				if(!item.IsAir && item.ModItem != null && item.ModItem is CombatPetEmblem petEmblem)
@@ -210,6 +211,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 						maxLevel = petEmblem.PetLevel;
 						maxDamage = item.damage;
 						maxItem = item;
+						PetEmblemItem = item.type;
 					}
 				}
 			}
@@ -229,7 +231,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 				}
 			}
 			UpdatePetLevel(maxLevel, maxDamage);
-			GetCrossModEmblemStats(this, maxItem);
+			CrossMod.GetCrossModEmblemStats(this, maxItem);
 		}
 
 		private void ReflagPetBuffs()

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
@@ -197,6 +197,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 			}
 			int maxLevel = 0;
 			int maxDamage = CombatPetLevelTable.PetLevelTable[0].BaseDamage;
+			Item maxItem = null;
 			for(int i = 0; i < Player.inventory.Length; i++)
 			{
 				Item item = Player.inventory[i];
@@ -207,6 +208,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 					{
 						maxLevel = petEmblem.PetLevel;
 						maxDamage = item.damage;
+						maxItem = item;
 					}
 				}
 			}
@@ -220,10 +222,12 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 					{
 						maxLevel = petEmblem.PetLevel;
 						maxDamage = item.damage;
+						maxItem = item;
 					}
 				}
 			}
 			UpdatePetLevel(maxLevel, maxDamage);
+			GetCrossModEmblemStats(this, maxItem);
 		}
 
 		private void ReflagPetBuffs()

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
@@ -134,7 +134,19 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 		private List<int> BuffsToAddOnRespawn = new();
 		public void UpdatePetLevel(int newLevel, int newDamage, int newEmblemItem, object[] newModdedStats, bool fromSync = false)
 		{
-			bool didUpdate = newLevel != PetLevel || PetDamage != newDamage || PetModdedStats.Length != newModdedStats.Length;
+			bool didUpdate = newLevel != PetLevel || PetDamage != newDamage;
+			PetLevel = newLevel;
+			PetDamage = newDamage;
+			if (didUpdate && !fromSync)
+			{
+				// TODO MP packet
+				new CombatPetLevelPacket(Player, (byte)PetLevel, (short)PetDamage).Send();
+			}
+		}
+		
+		public void UpdatePetLevelModded(int newEmblemItem, object[] newModdedStats, bool fromSync = false)
+		{
+			bool didUpdate = PetEmblemItem != newEmblemItem || PetModdedStats.Length != newModdedStats.Length;
 			if (!didUpdate) {
 				for (int x = 0; x < PetModdedStats.Length; x++) {
 					if (PetModdedStats[x] != newModdedStats[x]) {
@@ -143,14 +155,12 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 					}
 				}
 			}
-			PetLevel = newLevel;
-			PetDamage = newDamage;
 			PetEmblemItem = newEmblemItem;
 			PetModdedStats = newModdedStats;
 			if (didUpdate && !fromSync)
 			{
 				// TODO MP packet
-				new CombatPetLevelPacket(Player, (byte)PetLevel, (short)PetDamage, PetEmblemItem, PetModdedStats).Send();
+				new CombatPetLevelPacketModded(Player, PetEmblemItem, PetModdedStats).Send();
 			}
 		}
 
@@ -258,7 +268,8 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 					}
 				}
 			}
-			UpdatePetLevel(maxLevel, maxDamage, maxEmblemItem, CrossMod.GetCrossModEmblemStats(maxItem));
+			UpdatePetLevel(maxLevel, maxDamage);
+			UpdatePetLevelModded(maxEmblemItem, CrossMod.GetCrossModEmblemStats(maxItem));
 		}
 
 		private void ReflagPetBuffs()

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
@@ -111,6 +111,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 		internal int PetLevel { get; set; }
 		internal int PetDamage { get; set; }
 		
+		public int PetEmblemItem = -1;
 		public object[] PetModdedStats = null;
 
 		// todo this may be too many constructors, but it's a struct so I think it's ok
@@ -223,6 +224,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 						maxLevel = petEmblem.PetLevel;
 						maxDamage = item.damage;
 						maxItem = item;
+						PetEmblemItem = item.type;
 					}
 				}
 			}

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
@@ -132,7 +132,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 		private int buffResetCountdown;
 
 		private List<int> BuffsToAddOnRespawn = new();
-		public void UpdatePetLevel(int newLevel, int newDamage, object[] newModdedStats, bool fromSync = false)
+		public void UpdatePetLevel(int newLevel, int newDamage, int newEmblemItem, object[] newModdedStats, bool fromSync = false)
 		{
 			bool didUpdate = newLevel != PetLevel || PetDamage != newDamage || PetModdedStats.Length != newModdedStats.Length;
 			if (!didUpdate) {
@@ -145,11 +145,12 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 			}
 			PetLevel = newLevel;
 			PetDamage = newDamage;
+			PetEmblemItem = newEmblemItem;
 			PetModdedStats = newModdedStats;
 			if (didUpdate && !fromSync)
 			{
 				// TODO MP packet
-				new CombatPetLevelPacket(Player, (byte)PetLevel, (short)PetDamage, PetModdedStats).Send();
+				new CombatPetLevelPacket(Player, (byte)PetLevel, (short)PetDamage, PetEmblemItem, PetModdedStats).Send();
 			}
 		}
 
@@ -226,7 +227,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 			int maxLevel = 0;
 			int maxDamage = CombatPetLevelTable.PetLevelTable[0].BaseDamage;
 			Item maxItem = null;
-			PetEmblemItem = -1;
+			int maxEmblemItem = -1;
 			for (int i = 0; i < Player.inventory.Length; i++)
 			{
 				Item item = Player.inventory[i];
@@ -238,7 +239,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 						maxLevel = petEmblem.PetLevel;
 						maxDamage = item.damage;
 						maxItem = item;
-						PetEmblemItem = item.type;
+						maxEmblemItem = item.type;
 					}
 				}
 			}
@@ -253,11 +254,11 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 						maxLevel = petEmblem.PetLevel;
 						maxDamage = item.damage;
 						maxItem = item;
-						PetEmblemItem = item.type;
+						maxEmblemItem = item.type;
 					}
 				}
 			}
-			UpdatePetLevel(maxLevel, maxDamage, CrossMod.GetCrossModEmblemStats(maxItem));
+			UpdatePetLevel(maxLevel, maxDamage, maxEmblemItem, CrossMod.GetCrossModEmblemStats(maxItem));
 		}
 
 		private void ReflagPetBuffs()

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
@@ -132,7 +132,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 		private int buffResetCountdown;
 
 		private List<int> BuffsToAddOnRespawn = new();
-		public void UpdatePetLevel(int newLevel, int newDamage, int newEmblemItem, object[] newModdedStats, bool fromSync = false)
+		public void UpdatePetLevel(int newLevel, int newDamage, bool fromSync = false)
 		{
 			bool didUpdate = newLevel != PetLevel || PetDamage != newDamage;
 			PetLevel = newLevel;
@@ -160,7 +160,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 			if (didUpdate && !fromSync)
 			{
 				// TODO MP packet
-				new CombatPetLevelPacketModded(Player, PetEmblemItem, PetModdedStats).Send();
+				new CombatPetLevelModdedPacket(Player, PetEmblemItem, PetModdedStats).Send();
 			}
 		}
 

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetSlimeMinion.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetSlimeMinion.cs
@@ -56,6 +56,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets.CombatPetBaseClasse
 			searchDistance = leveledPetPlayer.PetLevelInfo.BaseSearchRange;
 			int petLevel = leveledPetPlayer.PetLevel;
 			idleInertia = petLevel < 4 ? 15 : 18 - petLevel;
+			CrossMod.CombatPetComputeMinionStats(Projectile, leveledPetPlayer);
 			return base.IdleBehavior();
 		}
 

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetWormMinion.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetWormMinion.cs
@@ -126,6 +126,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets.CombatPetBaseClasse
 		public override Vector2 IdleBehavior()
 		{
 			leveledPetPlayer = player.GetModPlayer<LeveledCombatPetModPlayer>();
+			CrossMod.CombatPetComputeMinionStats(Projectile, leveledPetPlayer);
 			return base.IdleBehavior();
 		}
 

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetWormMinion.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetWormMinion.cs
@@ -45,6 +45,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets.CombatPetBaseClasse
 			{
 				Projectile.localNPCHitCooldown = 25;
 			}
+			CrossMod.CombatPetComputeMinionStats(Projectile, leveledPetPlayer);
 			return target;
 		}
 


### PR DESCRIPTION
You can now increase the speed/crit/ability power/give a default special ability to your minions by changing or reforging the combat pet emblem