### PR TITLE
Added minion power pin compatibility to Combat Pets/WoF Minion. + Fixed Squire stats being affected by Summoner's Shine when Custom Minion Powers are off

### DIFF
--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -531,7 +531,7 @@ namespace AmuletOfManyMinions
 					summonersShine.Call(MODIFYCONFIGS, HOOKBUFFTOITEM, BuffType, ItemType);
 				}
 				else
-					summonersShine.Call(HOOKBUFFCONSTS, DISPLAYOVERRIDE, BuffType, (int i) => ItemTypes);
+					summonersShine.Call(HOOKBUFFCONSTS, BuffType, DISPLAYOVERRIDE, (int i) => ItemTypes);
 			}
 		}
 
@@ -548,7 +548,7 @@ namespace AmuletOfManyMinions
 			const int DISPLAYOVERRIDE = 1;
 			if (ModLoader.TryGetMod("SummonersShine", out Mod summonersShine))
 			{
-				summonersShine.Call(HOOKBUFFCONSTS, DISPLAYOVERRIDE, BuffType, SummonersShineEmblemDisplayOverride);
+				summonersShine.Call(HOOKBUFFCONSTS, BuffType, DISPLAYOVERRIDE, SummonersShineEmblemDisplayOverride);
 			}
 		}
 	}

--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -513,5 +513,23 @@ namespace AmuletOfManyMinions
 			}
 			return rv;
 		}
+		
+		public static void HookBuffToItemCrossMod(int BuffType, int[] ItemTypes)
+		{
+			const int MODIFYCONFIGS = 0;
+			const int HOOKBUFFTOITEM = 9;
+			const int HOOKBUFFCONSTS = 17;
+			const int DISPLAYOVERRIDE = 1;
+			if (ModLoader.TryGetMod("SummonersShine", out Mod summonersShine))
+			{
+				if(ItemTypes.Length == 1)
+				{
+					int ItemType = ItemTypes[0];
+					summonersShine.Call(MODIFYCONFIGS, HOOKBUFFTOITEM, BuffType, ItemType);
+				}
+				else
+					summonersShine.Call(HOOKBUFFCONSTS, DISPLAYOVERRIDE, BuffType, (int i) => ItemTypes);
+			}
+		}
 	}
 }

--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -261,9 +261,12 @@ namespace AmuletOfManyMinions
 		{
 			const int USEFUL_FUNCS = 10;
 			const int GET_ALL_MINION_POWER_DATA = 10;
-			
+			const int IS_PROJECTILE_MINION_POWER_ENABLED = 13;
+
 			if (ModLoader.TryGetMod("SummonersShine", out Mod summonersShine))
 			{
+				if(!(bool)summonersShine.Call(USEFUL_FUNCS, IS_PROJECTILE_MINION_POWER_ENABLED, projectile))
+					return value;
 				Tuple<float, float, int, int, bool> rv = (Tuple<float, float, int, int, bool>)summonersShine.Call(USEFUL_FUNCS, GET_ALL_MINION_POWER_DATA, projectile, index);
 				float outValue = rv.Item1;
 				float original = rv.Item2;

--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -514,7 +514,7 @@ namespace AmuletOfManyMinions
 			return rv;
 		}
 		
-		public static void HookBuffToItemCrossMod(int BuffType, int[] ItemTypes)
+		public static void HookBuffToItemCrossMod(int BuffType, params int[] ItemTypes)
 		{
 			const int MODIFYCONFIGS = 0;
 			const int HOOKBUFFTOITEM = 9;

--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -539,7 +539,10 @@ namespace AmuletOfManyMinions
 		{
 			Player player = Main.player[Main.myPlayer];
 			LeveledCombatPetModPlayer playerFuncs = player.GetModPlayer<LeveledCombatPetModPlayer>();
-			return new int[] { playerFuncs.PetEmblemItem };
+			int rv = playerFuncs.PetEmblemItem;
+			if (rv == -1)
+				return null;
+			return new int[] { rv };
 		}
 
 		public static void HookCombatPetBuffToEmblemSourceItem(int BuffType)

--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -531,5 +531,22 @@ namespace AmuletOfManyMinions
 					summonersShine.Call(HOOKBUFFCONSTS, DISPLAYOVERRIDE, BuffType, (int i) => ItemTypes);
 			}
 		}
+
+		static int[] SummonersShineEmblemDisplayOverride(int BuffType)
+		{
+			Player player = Main.player[Main.myPlayer];
+			LeveledCombatPetModPlayer playerFuncs = player.GetModPlayer<LeveledCombatPetModPlayer>();
+			return new int[] { playerFuncs.PetEmblemItem };
+		}
+
+		public static void HookCombatPetBuffToEmblemSourceItem(int BuffType)
+		{
+			const int HOOKBUFFCONSTS = 17;
+			const int DISPLAYOVERRIDE = 1;
+			if (ModLoader.TryGetMod("SummonersShine", out Mod summonersShine))
+			{
+				summonersShine.Call(HOOKBUFFCONSTS, DISPLAYOVERRIDE, BuffType, SummonersShineEmblemDisplayOverride);
+			}
+		}
 	}
 }

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
@@ -375,6 +375,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 			Main.vanityPet[Type] = true;
 			Main.buffNoSave[Type] = false;
 			CombatPetBuffTypes.Add(Type);
+			CrossMod.HookCombatPetBuffToEmblemSourceItem(Type);
 		}
 
 		public override void Update(Player player, ref int buffIndex)

--- a/Projectiles/Squires/WoFSquire/WoFSquire.cs
+++ b/Projectiles/Squires/WoFSquire/WoFSquire.cs
@@ -37,6 +37,7 @@ namespace AmuletOfManyMinions.Projectiles.Squires.WoFSquire
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Wall of Flesh Squire");
 			Description.SetDefault("You can guide the Wall of Flesh!");
+			CrossMod.HookBuffToItemCrossMod(Type, ItemType<GuideVoodooSquireMinionItem>());
 		}
 		public override void Update(Player player, ref int buffIndex)
 		{


### PR DESCRIPTION
There was a bug whereby disabling custom minion powers in Summoner's Shine doesn't affect the minion power stat modifications

This also changes it so that the little pins denoting special ability readiness are properly attached to some problematic minion buffs.