### PR TITLE
Whitelist other default special abilities

### DIFF
--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -189,15 +189,92 @@ namespace AmuletOfManyMinions
 				// there are some weird speed/behavior inconsistencies
 				// with most minions, especially while following the waypoint,
 				// so give the option of disabling them all
-				if(ServerConfig.Instance.DisableSummonersShineAI)
+				if (ServerConfig.Instance.DisableSummonersShineAI)
 				{
 					IEnumerable<ModProjectile> minions = mod.GetContent<ModProjectile>().Where(p => p is Minion);
-					foreach(var minion in minions)
+					foreach (var minion in minions)
 					{
 						summonersShine.Call(ADD_FILTER, BLACKLIST_PROJECTILE, minion.Type);
 						summonersShine.Call(ADD_FILTER, DONT_COUNT_AS_MINION, minion.Type);
 					}
 				}
+
+
+				IEnumerable<ModProjectile> counterMinions = mod.GetContent<ModProjectile>().Where(p => p is CounterMinion);
+				foreach (var minion in counterMinions)
+				{
+					summonersShine.Call(ADD_FILTER, BLACKLIST_PROJECTILE, minion.Type);
+				}
+			}
+		}
+
+		public enum SummonersShineDefaultSpecialWhitelistType { 
+			RANGED,
+			MELEE,
+			RANGEDNOINSTASTRIKE,
+			MELEENOINSTASTRIKE,
+			RANGEDNOMULTISHOT,
+		}
+
+		static readonly BitsByte[] SUMMONERS_SHINE_RANGED_WHITELISTDEFAULTS = new BitsByte[] {
+			new BitsByte(
+				true, //multishot
+				true, //enrage (safe)
+				true) //instastrike (ranged)
+		};
+		
+		static readonly BitsByte[] SUMMONERS_SHINE_RANGED_WHITELISTDEFAULTS_NOMULTISHOT = new BitsByte[] {
+			new BitsByte(
+				false, //multishot
+				true, //enrage (safe)
+				true) //instastrike (ranged)
+		};
+
+		static readonly BitsByte[] SUMMONERS_SHINE_MELEE_WHITELISTDEFAULTS = new BitsByte[] {
+			new BitsByte(
+				false, //multishot
+				true, //enrage (safe)
+				false, //instastrike (ranged)
+				true) //instastrike (melee)
+		};
+		
+		static readonly BitsByte[] SUMMONERS_SHINE_RANGED_WHITELISTDEFAULTS_NOINSTASTRIKE = new BitsByte[] {
+			new BitsByte(
+				true, //multishot
+				true) //enrage (safe)
+		};
+		//this is default minion behavior
+		static readonly BitsByte[] SUMMONERS_SHINE_MELEE_WHITELISTDEFAULTS_NOINSTASTRIKE = new BitsByte[] {
+			new BitsByte(
+				false, //multishot
+				true) //enrage (safe)
+		};
+		public static void WhitelistSummonersShineMinionDefaultSpecialAbility(int ItemType, SummonersShineDefaultSpecialWhitelistType specialWhitelistType)
+		{
+			if (ModLoader.TryGetMod("SummonersShine", out Mod summonersShine))
+			{
+				BitsByte[] enabledData = null;
+				switch (specialWhitelistType)
+				{
+					case SummonersShineDefaultSpecialWhitelistType.RANGED:
+						enabledData = SUMMONERS_SHINE_RANGED_WHITELISTDEFAULTS;
+						break;
+					case SummonersShineDefaultSpecialWhitelistType.MELEE:
+						enabledData = SUMMONERS_SHINE_MELEE_WHITELISTDEFAULTS;
+						break;
+					case SummonersShineDefaultSpecialWhitelistType.RANGEDNOINSTASTRIKE:
+						enabledData = SUMMONERS_SHINE_RANGED_WHITELISTDEFAULTS_NOINSTASTRIKE;
+						break;
+					case SummonersShineDefaultSpecialWhitelistType.MELEENOINSTASTRIKE:
+						enabledData = SUMMONERS_SHINE_MELEE_WHITELISTDEFAULTS_NOINSTASTRIKE;
+						break;
+					case SummonersShineDefaultSpecialWhitelistType.RANGEDNOMULTISHOT:
+						enabledData = SUMMONERS_SHINE_RANGED_WHITELISTDEFAULTS_NOMULTISHOT;
+							break;
+				}
+				const int ADD_FILTER = 0;
+				const int DEFAULTSPECIALABILITYWHITELIST = 4;
+				summonersShine.Call(ADD_FILTER, DEFAULTSPECIALABILITYWHITELIST, ItemType, enabledData);
 			}
 		}
 		

--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -273,7 +273,7 @@ namespace AmuletOfManyMinions
 							break;
 				}
 				const int ADD_FILTER = 0;
-				const int DEFAULTSPECIALABILITYWHITELIST = 4;
+				const int DEFAULTSPECIALABILITYWHITELIST = 13;
 				summonersShine.Call(ADD_FILTER, DEFAULTSPECIALABILITYWHITELIST, ItemType, enabledData);
 			}
 		}

--- a/Projectiles/Minions/Acorn/Acorn.cs
+++ b/Projectiles/Minions/Acorn/Acorn.cs
@@ -28,6 +28,11 @@ namespace AmuletOfManyMinions.Projectiles.Minions.Acorn
 			DisplayName.SetDefault("Acorn Staff");
 			Tooltip.SetDefault("Summons a winged acorn to fight for you!");
 		}
+		
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGEDNOMULTISHOT);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/BalloonBuddy/BalloonBuddy.cs
+++ b/Projectiles/Minions/BalloonBuddy/BalloonBuddy.cs
@@ -29,6 +29,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.BalloonBuddy
 			Tooltip.SetDefault("Summons an enchanted balloon animal to fight for you!");
 
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/BalloonMonkey/BalloonMonkey.cs
+++ b/Projectiles/Minions/BalloonMonkey/BalloonMonkey.cs
@@ -32,6 +32,11 @@ namespace AmuletOfManyMinions.Projectiles.Minions.BalloonMonkey
 			DisplayName.SetDefault("Staff of Darts");
 			Tooltip.SetDefault("Summons a dart-throwing monkey to fight for you!");
 		}
+		
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGED);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/BeeQueen/BeeQueen.cs
+++ b/Projectiles/Minions/BeeQueen/BeeQueen.cs
@@ -29,6 +29,11 @@ namespace AmuletOfManyMinions.Projectiles.Minions.BeeQueen
 			DisplayName.SetDefault("Bee Queen's Crown");
 			Tooltip.SetDefault("Summons a bee assistant to fight for you!");
 		}
+		
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGEDNOMULTISHOT);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/BoneSerpent/BoneSerpent.cs
+++ b/Projectiles/Minions/BoneSerpent/BoneSerpent.cs
@@ -29,6 +29,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.BoneSerpent
 			Tooltip.SetDefault("Summons a skeletal dragon to fight for you!");
 
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetGroundedMinion.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetGroundedMinion.cs
@@ -24,6 +24,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets.CombatPetBaseClasse
 			base.SetStaticDefaults();
 			Main.projPet[Projectile.type] = true;
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetGroundedMinion.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetGroundedMinion.cs
@@ -24,10 +24,6 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets.CombatPetBaseClasse
 			base.SetStaticDefaults();
 			Main.projPet[Projectile.type] = true;
 		}
-		public override void ApplyCrossModChanges()
-		{
-			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
-		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/CorruptionAltar/CorruptionAltar.cs
+++ b/Projectiles/Minions/CorruptionAltar/CorruptionAltar.cs
@@ -30,6 +30,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CorruptionAltar
 			DisplayName.SetDefault("Corruption Cell Staff");
 			Tooltip.SetDefault("Summons a corrupt cell to fight for you!");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGED);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/CrimsonAltar/CrimsonAltar.cs
+++ b/Projectiles/Minions/CrimsonAltar/CrimsonAltar.cs
@@ -30,6 +30,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CrimsonAltar
 			DisplayName.SetDefault("Crimson Cell Staff");
 			Tooltip.SetDefault("Summons a crimson cell to fight for you!");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGED);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/CrystalFist/CrystalFistMinion.cs
+++ b/Projectiles/Minions/CrystalFist/CrystalFistMinion.cs
@@ -40,6 +40,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CrystalFist
 			Item.value = Item.buyPrice(0, 12, 0, 0);
 			Item.rare = ItemRarityID.Pink;
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
 		{

--- a/Projectiles/Minions/EclipseHerald/EclipseHerald.cs
+++ b/Projectiles/Minions/EclipseHerald/EclipseHerald.cs
@@ -28,6 +28,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.EclipseHerald
 			DisplayName.SetDefault("Eclipse Herald Staff");
 			Tooltip.SetDefault("Can't come to grips \nWith the total eclipse \nJust a slip of your lips \nand you're gone...");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGED);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/ExciteSkull/ExciteSkull.cs
+++ b/Projectiles/Minions/ExciteSkull/ExciteSkull.cs
@@ -28,6 +28,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.ExciteSkull
 			DisplayName.SetDefault("Skeletal Keychain");
 			Tooltip.SetDefault("Summons a skull biker to fight for you!");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/FishBowl/FishBowl.cs
+++ b/Projectiles/Minions/FishBowl/FishBowl.cs
@@ -32,6 +32,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.FishBowl
 			Tooltip.SetDefault("Summons a flying fishbowl to fight for you!\n"+
 				"Most effective against flying enemies");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGED);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/FlyingSword/FlyingSword.cs
+++ b/Projectiles/Minions/FlyingSword/FlyingSword.cs
@@ -27,6 +27,11 @@ namespace AmuletOfManyMinions.Projectiles.Minions.FlyingSword
 			DisplayName.SetDefault("Clarent");
 			Tooltip.SetDefault("Summons a flying sword to fight for you!");
 		}
+		
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/GoblinGunner/GoblinGunner.cs
+++ b/Projectiles/Minions/GoblinGunner/GoblinGunner.cs
@@ -30,6 +30,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.GoblinGunner
 			DisplayName.SetDefault("Goblin Radio Beacon");
 			Tooltip.SetDefault("Summons a goblin gunship to fight for you!");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGED);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/GoblinTechnomancer/GoblinTechnomancer.cs
+++ b/Projectiles/Minions/GoblinTechnomancer/GoblinTechnomancer.cs
@@ -32,6 +32,11 @@ namespace AmuletOfManyMinions.Projectiles.Minions.GoblinTechnomancer
 			DisplayName.SetDefault("Shadowflame Probe Controller");
 			Tooltip.SetDefault("Summons a goblin technomancer to fight for you!");
 		}
+		
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGED);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/MeteorFist/MeteorFist.cs
+++ b/Projectiles/Minions/MeteorFist/MeteorFist.cs
@@ -28,6 +28,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.MeteorFist
 			DisplayName.SetDefault("Meteor Fist");
 			Tooltip.SetDefault("Summons a meteor fist to fight for you!");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/MinonBaseClasses/SurferMinion.cs
+++ b/Projectiles/Minions/MinonBaseClasses/SurferMinion.cs
@@ -24,6 +24,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.MinonBaseClasses
 			Main.projFrames[Projectile.type] = 6;
 			IdleLocationSets.circlingHead.Add(Projectile.type);
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void OnHitTarget(NPC target)
 		{

--- a/Projectiles/Minions/Necromancer/Necromancer.cs
+++ b/Projectiles/Minions/Necromancer/Necromancer.cs
@@ -21,6 +21,11 @@ namespace AmuletOfManyMinions.Projectiles.Minions.Necromancer
 			DisplayName.SetDefault("Necromancer");
 			Description.SetDefault("A necromancer and his skeletal servants will fight for you!");
 		}
+		
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGED);
+		}
 	}
 
 	public class NecromancerMinionItem : MinionItem<NecromancerMinionBuff, NecromancerSkeletonMinion>

--- a/Projectiles/Minions/NullHatchet/NullHatchet.cs
+++ b/Projectiles/Minions/NullHatchet/NullHatchet.cs
@@ -28,6 +28,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.NullHatchet
 			DisplayName.SetDefault("Null Hatchet");
 			Tooltip.SetDefault("Summons an ethereal axe to fight for you!");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/PossessedCopperSword/PossessedCopperSword.cs
+++ b/Projectiles/Minions/PossessedCopperSword/PossessedCopperSword.cs
@@ -28,6 +28,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.PossessedCopperSword
 			DisplayName.SetDefault("Starry SkySlasher");
 			Tooltip.SetDefault("Summons an enchanted sword to fight for you!");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/PricklyPear/PricklyPear.cs
+++ b/Projectiles/Minions/PricklyPear/PricklyPear.cs
@@ -29,6 +29,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.PricklyPear
 			DisplayName.SetDefault("Prickly Pear Staff");
 			Tooltip.SetDefault("Summons a prickly pear hedgehog to fight for you!");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGED);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/Rats/Rats.cs
+++ b/Projectiles/Minions/Rats/Rats.cs
@@ -32,6 +32,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.Rats
 			DisplayName.SetDefault("Rod of the Ratkeeper");
 			Tooltip.SetDefault("Summons a hoarde of rats to fight for you!\nEach rat deals 1/3 of base damage,\nand ignores 10 enemy defense");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/Slimecart/Slimecart.cs
+++ b/Projectiles/Minions/Slimecart/Slimecart.cs
@@ -29,6 +29,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.Slimecart
 			DisplayName.SetDefault("Slimecart Staff");
 			Tooltip.SetDefault("Summons slime miner to fight for you!");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/Slimepire/Slimepire.cs
+++ b/Projectiles/Minions/Slimepire/Slimepire.cs
@@ -26,6 +26,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.Slimepire
 			DisplayName.SetDefault("Slimepire Staff");
 			Tooltip.SetDefault("Summons a vampire slime to fight for you!\nIgnores 10 enemy defense");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/SpiritGun/SpiritGun.cs
+++ b/Projectiles/Minions/SpiritGun/SpiritGun.cs
@@ -30,6 +30,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.SpiritGun
 			DisplayName.SetDefault("Spirit Revolver");
 			Tooltip.SetDefault("Summons sentient bullets to fight for you.\nMake sure they don't get hungry...");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGEDNOMULTISHOT);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/StoneCloud/StoneCloud.cs
+++ b/Projectiles/Minions/StoneCloud/StoneCloud.cs
@@ -28,6 +28,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.StoneCloud
 			DisplayName.SetDefault("Cloud in a Boulder");
 			Tooltip.SetDefault("Summons an extremely dense cloud to fight for you!\nDeals high damage, but attacks very slowly");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/TumbleSheep/TumbleSheep.cs
+++ b/Projectiles/Minions/TumbleSheep/TumbleSheep.cs
@@ -33,6 +33,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.TumbleSheep
 			DisplayName.SetDefault("Shepherd's Staff");
 			Tooltip.SetDefault("Summons a tumbling sheep to fight for you!");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/VoidKnife/VoidKnife.cs
+++ b/Projectiles/Minions/VoidKnife/VoidKnife.cs
@@ -28,6 +28,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.VoidKnife
 			DisplayName.SetDefault("Void Dagger");
 			Tooltip.SetDefault("Summons an ethereal dagger to fight for you!");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/WhackAMole/WhackAMole.cs
+++ b/Projectiles/Minions/WhackAMole/WhackAMole.cs
@@ -29,6 +29,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.WhackAMole
 			DisplayName.SetDefault("Magic Jelly Bean Jar");
 			Tooltip.SetDefault("Summons a stack of magic moles to fight for you!");
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/XCXCopter/XCXCopter.cs
+++ b/Projectiles/Minions/XCXCopter/XCXCopter.cs
@@ -29,6 +29,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.XCXCopter
 			Tooltip.SetDefault("Summons a flexible helicopter to fight for you!");
 
 		}
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.MELEE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Squires/AncientCobaltSquire/AncientCobaltSquire.cs
+++ b/Projectiles/Squires/AncientCobaltSquire/AncientCobaltSquire.cs
@@ -35,6 +35,8 @@ namespace AmuletOfManyMinions.Projectiles.Squires.AncientCobaltSquire
 			CrossMod.SummonersShineMinionPowerCollection minionCollection = new CrossMod.SummonersShineMinionPowerCollection();
 			minionCollection.AddMinionPower(100f);
 			CrossMod.BakeSummonersShineMinionPower_NoHooks(Item.type, minionCollection);
+			
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGEDNOINSTASTRIKE);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/Squires/GoldenRogueSquire/GoldenRogueSquire.cs
+++ b/Projectiles/Squires/GoldenRogueSquire/GoldenRogueSquire.cs
@@ -32,6 +32,11 @@ namespace AmuletOfManyMinions.Projectiles.Squires.GoldenRogueSquire
 			DisplayName.SetDefault("Golden Rogue Crest");
 			Tooltip.SetDefault("Summons a squire\nA golden rogue squire will fight for you!\nClick and hold to guide its attacks");
 		}
+		
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGEDNOINSTASTRIKE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Squires/PumpkinSquire/PumpkinSquire.cs
+++ b/Projectiles/Squires/PumpkinSquire/PumpkinSquire.cs
@@ -32,6 +32,9 @@ namespace AmuletOfManyMinions.Projectiles.Squires.PumpkinSquire
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Pumpkin Crest");
 			Tooltip.SetDefault("Summons a squire\nA pumpkin squire will fight for you!\nClick and hold to guide its attacks");
+		}public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGEDNOINSTASTRIKE);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/Squires/SoulboundArsenal/SoulboundAresnal.cs
+++ b/Projectiles/Squires/SoulboundArsenal/SoulboundAresnal.cs
@@ -38,6 +38,11 @@ namespace AmuletOfManyMinions.Projectiles.Squires.SoulboundArsenal
 			DisplayName.SetDefault("Soulbound Arsenal");
 			Tooltip.SetDefault("Summons a squire\nA soulbound bow and sword will fight for you!\nClick and hold to guide their attacks");
 		}
+		
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGEDNOINSTASTRIKE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Squires/SoulboundBow/SoulboundBow.cs
+++ b/Projectiles/Squires/SoulboundBow/SoulboundBow.cs
@@ -35,6 +35,11 @@ namespace AmuletOfManyMinions.Projectiles.Squires.SoulboundBow
 			DisplayName.SetDefault("Soulbound Bow");
 			Tooltip.SetDefault("Summons a squire\nAn enchanted bow will fight for you!\nClick and hold to guide its attacks");
 		}
+		
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGEDNOINSTASTRIKE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Squires/SoulboundSword/SoulboundSword.cs
+++ b/Projectiles/Squires/SoulboundSword/SoulboundSword.cs
@@ -33,6 +33,11 @@ namespace AmuletOfManyMinions.Projectiles.Squires.SoulboundSword
 			DisplayName.SetDefault("Soulbound Sword");
 			Tooltip.SetDefault("Summons a squire\nAn enchanted sword will fight for you!\nClick and hold to guide its attacks");
 		}
+		
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGEDNOINSTASTRIKE);
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Squires/Squeyere/Squeyere.cs
+++ b/Projectiles/Squires/Squeyere/Squeyere.cs
@@ -32,6 +32,11 @@ namespace AmuletOfManyMinions.Projectiles.Squires.Squeyere
 			Tooltip.SetDefault("Summons a squire\nA Squeyere will fight for you!\nClick and hold to guide its attacks\n" +
 				"'Squ-Eye-Re. Get it?'");
 		}
+		
+		public override void ApplyCrossModChanges()
+		{
+			CrossMod.WhitelistSummonersShineMinionDefaultSpecialAbility(Item.type, CrossMod.SummonersShineDefaultSpecialWhitelistType.RANGEDNOINSTASTRIKE);
+		}
 
 		public override void SetDefaults()
 		{


### PR DESCRIPTION
Typically, only Default Special Ability 1 is mostly mod-safe. However, now that we can blacklist/control other stuff, we can whitelist other default specials.