### PR TITLE
Summoner's Shine Bloodtaint Mode Compatibility

### DIFF
--- a/CrossMod.cs
+++ b/CrossMod.cs
@@ -182,6 +182,7 @@ namespace AmuletOfManyMinions
 			const int ADD_FILTER = 0;
 			const int BLACKLIST_PROJECTILE = 1;
 			const int DONT_COUNT_AS_MINION = 4;
+			const int COUNTS_AS_WHIP_FOR_INSTASTRIKE = 14;
 			if (ModLoader.TryGetMod("SummonersShine", out Mod summonersShine))
 			{
 				SummonersShineLoaded = true;
@@ -212,6 +213,12 @@ namespace AmuletOfManyMinions
 				foreach (var minion in counterMinions)
 				{
 					summonersShine.Call(ADD_FILTER, BLACKLIST_PROJECTILE, minion.Type);
+				}
+				
+				IEnumerable<ModItem> squireItems = mod.GetContent<ModItem>().Where(p => p is SquireMinionItemDetector);
+				foreach (var squireItem in squireItems)
+				{
+					summonersShine.Call(ADD_FILTER, COUNTS_AS_WHIP_FOR_INSTASTRIKE, squireItem.Type);
 				}
 			}
 		}

--- a/Projectiles/Squires/SquireMinionItem.cs
+++ b/Projectiles/Squires/SquireMinionItem.cs
@@ -9,7 +9,8 @@ using Terraria.ModLoader;
 
 namespace AmuletOfManyMinions.Projectiles.Squires
 {
-	public abstract class SquireMinionItem<TBuff, TProj> : MinionItem<TBuff, TProj> where TBuff : ModBuff where TProj : SquireMinion
+	public interface SquireMinionItemDetector { }
+	public abstract class SquireMinionItem<TBuff, TProj> : MinionItem<TBuff, TProj>, SquireMinionItemDetector where TBuff : ModBuff where TProj : SquireMinion
 	{
 
 		protected abstract string SpecialName { get; }


### PR DESCRIPTION
Squires are now considered Whips for the purposes of Instastrike

Squires are no longer slowed by Bloodtaint