### PR TITLE
CanUseItem revisit

### DIFF
--- a/Items/WaypointRods/WaypointRods.cs
+++ b/Items/WaypointRods/WaypointRods.cs
@@ -47,7 +47,12 @@ namespace AmuletOfManyMinions.Items.WaypointRods
 
 		public override bool? UseItem(Player player)
 		{
-			// it seems that it's possible to useItem without calling SetDefaults somehow, so check here as well
+			if (player.altFunctionUse == 2)
+			{
+				return false;
+			}
+
+            // it seems that it's possible to useItem without calling SetDefaults somehow, so check here as well
 			if(placementRange == 0)
 			{
 				placementRange = 16 * placementRangeInBlocks;
@@ -66,14 +71,12 @@ namespace AmuletOfManyMinions.Items.WaypointRods
 			return true;
 		}
 
-		public override bool CanUseItem(Player player)
+		public override void UseAnimation(Player player)
 		{
 			if (player.altFunctionUse == 2 && Main.myPlayer == player.whoAmI)
 			{
 				UserInterfaces.buffClickCapture.PlaceTacticSelectRadial(UserInterfaces.MousePositionUI);
-				return false;
 			}
-			return base.CanUseItem(player);
 		}
 
 		public override void ModifyTooltips(List<TooltipLine> tooltips)

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
@@ -453,6 +453,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 
 		// hack to temporarily un-flag buffs as pet type to prevent vanilla removal code from running
 		// depending on how many open combat pet slots the player has
+		// TODO figure out how to move the hack to avoid using CanUseItem entirely, possibly look into how and what EmpoweredMinionSacrificeCircumventionSystem does (if applicable vanilla method to detour exists)
 		public static bool CanUseItem(Player player, Item item)
 		{
 			LeveledCombatPetModPlayer petPlayer = player.GetModPlayer<LeveledCombatPetModPlayer>();

--- a/Projectiles/Minions/VanillaClones/VanillaCloneMinionItem.cs
+++ b/Projectiles/Minions/VanillaClones/VanillaCloneMinionItem.cs
@@ -35,12 +35,20 @@ namespace AmuletOfManyMinions.Projectiles.Minions.VanillaClones
 
 		public override void AddRecipes()
 		{
+#if TML_2022_05
 			Recipe recipe = Mod.CreateRecipe(VanillaItemID);
+#else
+			Recipe recipe = Recipe.Create(VanillaItemID);
+#endif
 			recipe.AddIngredient(Type, 1);
 			recipe.AddTile(TileID.DemonAltar);
 			recipe.Register();
 
+#if TML_2022_05
 			Recipe reciprocal = Mod.CreateRecipe(Type);
+#else
+			Recipe reciprocal = Recipe.Create(Type);
+#endif
 			reciprocal.AddIngredient(VanillaItemID, 1);
 			reciprocal.AddTile(TileID.DemonAltar);
 			reciprocal.Register();

--- a/Projectiles/Squires/SoulboundArsenal/SoulboundAresnal.cs
+++ b/Projectiles/Squires/SoulboundArsenal/SoulboundAresnal.cs
@@ -60,11 +60,11 @@ namespace AmuletOfManyMinions.Projectiles.Squires.SoulboundArsenal
 		{
 			CreateRecipe(1).AddIngredient(ItemID.BrokenHeroSword, 1).AddIngredient(ItemType<SoulboundSwordMinionItem>(), 1).AddIngredient(ItemType<SoulboundBowMinionItem>(), 1).AddTile(TileID.MythrilAnvil).Register();
 		}
-		public override bool CanUseItem(Player player)
+
+		public override void UseAnimation(Player player)
 		{
-			var canUse = base.CanUseItem(player);
+			base.UseAnimation(player);
 			Item.noUseGraphic = true;
-			return canUse;
 		}
 	}
 

--- a/Projectiles/Squires/SoulboundBow/SoulboundBow.cs
+++ b/Projectiles/Squires/SoulboundBow/SoulboundBow.cs
@@ -58,11 +58,10 @@ namespace AmuletOfManyMinions.Projectiles.Squires.SoulboundBow
 			CreateRecipe(1).AddIngredient(ItemID.PearlwoodBow, 1).AddIngredient(ItemID.SoulofLight, 10).AddTile(TileID.Anvils).Register();
 		}
 
-		public override bool CanUseItem(Player player)
+		public override void UseAnimation(Player player)
 		{
-			var canUse = base.CanUseItem(player);
+			base.UseAnimation(player);
 			Item.noUseGraphic = true;
-			return canUse;
 		}
 	}
 

--- a/Projectiles/Squires/SoulboundSword/SoulboundSword.cs
+++ b/Projectiles/Squires/SoulboundSword/SoulboundSword.cs
@@ -55,11 +55,11 @@ namespace AmuletOfManyMinions.Projectiles.Squires.SoulboundSword
 		{
 			CreateRecipe(1).AddRecipeGroup("AmuletOfManyMinions:EvilWoodSwords").AddIngredient(ItemID.SoulofNight, 10).AddTile(TileID.Anvils).Register();
 		}
-		public override bool CanUseItem(Player player)
+
+		public override void UseAnimation(Player player)
 		{
-			var canUse = base.CanUseItem(player);
+			base.UseAnimation(player);
 			Item.noUseGraphic = true;
-			return canUse;
 		}
 	}
 

--- a/Projectiles/Squires/SquireMinionItem.cs
+++ b/Projectiles/Squires/SquireMinionItem.cs
@@ -62,7 +62,7 @@ namespace AmuletOfManyMinions.Projectiles.Squires
 			return true;
 		}
 
-		public override bool CanUseItem(Player player)
+		public override void UseAnimation(Player player)
 		{
 			if (player.ownedProjectileCounts[Item.shoot] > 0)
 			{
@@ -76,7 +76,6 @@ namespace AmuletOfManyMinions.Projectiles.Squires
 				Item.noUseGraphic = false;
 				Item.UseSound = SoundID.Item44;
 			}
-			return true;
 		}
 
 		public override void ModifyTooltips(List<TooltipLine> tooltips)

--- a/Projectiles/Squires/WoFSquire/WoFSquire.cs
+++ b/Projectiles/Squires/WoFSquire/WoFSquire.cs
@@ -84,9 +84,9 @@ namespace AmuletOfManyMinions.Projectiles.Squires.WoFSquire
 			return base.CanShoot(player);
 		}
 
-		public override bool CanUseItem(Player player)
+		public override void UseAnimation(Player player)
 		{
-			base.CanUseItem(player);
+			base.UseAnimation(player);
 			if (player.ownedProjectileCounts[Item.shoot] > 0 || player.ownedProjectileCounts[wofType] > 0)
 			{
 				Item.UseSound = null;
@@ -99,8 +99,8 @@ namespace AmuletOfManyMinions.Projectiles.Squires.WoFSquire
 				Item.noUseGraphic = false;
 				Item.UseSound = SoundID.Item44;
 			}
-			return true;
 		}
+
 		public override void AddRecipes()
 		{
 			CreateRecipe(1).AddIngredient(ItemID.GuideVoodooDoll, 1).AddIngredient(ItemType<GuideSquireMinionItem>(), 1).AddIngredient(ItemType<GuideHair>(), 1).AddTile(TileID.LunarCraftingStation).Register();


### PR DESCRIPTION
This PR fixes "abuse" of the CanUseItem hook where possible ("abuse" meaning "performing actions that change the state"), as 1.4 tml now shortcirquits the hooks if one returns false (not reliable anymore)

Left a TODO for one CanUseItem case that I don't know how to fix, and probably won't fix.

Also fixes compilation on preview while keeping compilation on stable intact.