### PR TITLE
Several MP fixes, resolve a TODO, cleanup

### DIFF
--- a/Core/MinionTacticsPlayer.cs
+++ b/Core/MinionTacticsPlayer.cs
@@ -30,24 +30,30 @@ namespace AmuletOfManyMinions.Core.Minions
 		public static int MAX_TACTICS_GROUP = TACTICS_GROUPS_COUNT -1;
 
 		// The list of tactics "teams" belonging to the player
-		public PlayerTargetSelectionTactic[] PlayerTacticsGroups = new PlayerTargetSelectionTactic[TACTICS_GROUPS_COUNT];
-		public byte[] TacticsIDs = new byte[TACTICS_GROUPS_COUNT];
+		public PlayerTargetSelectionTactic[] PlayerTacticsGroups;
+		public byte[] TacticIDByGroup;
 
 		// The active tactics group
 		public int CurrentTacticGroup = 0;
 
 		// map from minion buff to tactics group
-		public Dictionary<int, int> MinionTacticsMap = new Dictionary<int, int>();
+		public Dictionary<int, int> MinionTacticsMap;
 		private bool setInstancedCollections;
 
-		public byte TacticID { get => TacticsIDs[CurrentTacticGroup]; private set => TacticsIDs[CurrentTacticGroup] = value; }
-
+		public byte TacticID
+		{
+			get => TacticIDByGroup[CurrentTacticGroup];
+			private set => TacticIDByGroup[CurrentTacticGroup] = value;
+		}
 
 		public TargetSelectionTactic SelectedTactic => TargetSelectionTacticHandler.GetTactic(TacticID);
 
 
-		public PlayerTargetSelectionTactic PlayerTactic { get => PlayerTacticsGroups[CurrentTacticGroup]; set => PlayerTacticsGroups[CurrentTacticGroup] = value; }
-
+		public PlayerTargetSelectionTactic PlayerTactic
+		{
+			get => PlayerTacticsGroups[CurrentTacticGroup];
+			set => PlayerTacticsGroups[CurrentTacticGroup] = value;
+		}
 
 		private List<byte> TacticIDCycle;
 
@@ -55,20 +61,7 @@ namespace AmuletOfManyMinions.Core.Minions
 		/// The list of buffs that have been altered for this modplayer since the last 
 		/// sync.
 		/// </summary>
-		private List<int> BuffIdsToSync = new List<int>();
-		/// <summary>
-		/// String array used to hold on to saved tactic names until OnEnterWorld is called
-		/// There seems to be a very strange interplay between Initialize and Load that causes
-		/// tactics to be overwritten back and forth between them, this is the simplest way 
-		/// to resolve.
-		/// </summary>
-		private string[] savedTacticsNames;
-
-		/// <summary>
-		/// byte array used to hold saved minion buff groups, for a similar workaround as 
-		/// savedTacticsNames
-		/// </summary>
-		private byte[] buffsToLoad;
+		private List<int> BuffIdsToSync;
 
 		private int PreviousTacticGroup = 0;
 		private byte PreviousTacticID = TargetSelectionTacticHandler.DefaultTacticID;
@@ -125,16 +118,16 @@ namespace AmuletOfManyMinions.Core.Minions
 		/// Update every tactic for the modplayer, and also their selected tactic.
 		/// Only used to update non-Main.myPlayer ModPlayers via netcode.
 		/// </summary>
-		/// <param name="tacticsIds"></param>
-		/// <param name="selectedTactic"></param>
-		internal void SetAllTactics(byte[] tacticsIds, byte? selectedTactic = null)
+		/// <param name="tacticIDByGroup"></param>
+		/// <param name="selectedTacticGroup"></param>
+		internal void SetAllTactics(byte[] tacticIDByGroup, byte? selectedTacticGroup = null)
 		{
 			// don't reallocate, not sure it really matters though
 			for(int i = 0; i < TACTICS_GROUPS_COUNT; i++)
 			{
-				TacticsIDs[i] = tacticsIds[i];
+				TacticIDByGroup[i] = tacticIDByGroup[i];
 			}
-			if(selectedTactic is byte selected)
+			if(selectedTacticGroup is byte selected)
 			{
 				CurrentTacticGroup = selected;
 			}
@@ -164,6 +157,10 @@ namespace AmuletOfManyMinions.Core.Minions
 
 		public override void Initialize()
 		{
+			PlayerTacticsGroups = new PlayerTargetSelectionTactic[TACTICS_GROUPS_COUNT];
+			MinionTacticsMap = new Dictionary<int, int>();
+			BuffIdsToSync = new List<int>();
+
 			CurrentTacticGroup = 0;
 			SyncTimer = 0;
 			TacticIDCycle = new List<byte>
@@ -177,12 +174,19 @@ namespace AmuletOfManyMinions.Core.Minions
 				TargetSelectionTacticHandler.GetTactic<SpreadOut>().ID,
 				TargetSelectionTacticHandler.GetTactic<AttackGroups>().ID,
 			};
-		}
 
+			TacticIDByGroup = new byte[TACTICS_GROUPS_COUNT];
+			for (int i = 0; i < TACTICS_GROUPS_COUNT; i++)
+			{
+				//Initialize all tactic IDs with the first element from the cycle
+				TacticIDByGroup[i] = TacticIDCycle[0];
+			}
+		}
 
 		public override void SaveData(TagCompound tag)
 		{
-			string tacticsNameList = string.Join(",", TacticsIDs.Select(id => TargetSelectionTacticHandler.GetTactic(id).Name));
+			//Transform selected tactic per group into comma separated string of the tactic name (so in case of renames/removals, it will revert back to default)
+			string tacticsNameList = string.Join(",", TacticIDByGroup.Select(id => TargetSelectionTacticHandler.GetTactic(id).Name));
 			// 256 is probably generous enough to not require any resizing in most cases
 			MemoryStream stream = new MemoryStream(256);
 			MinionTacticsGroupMapper.WriteBuffMap(new BinaryWriter(stream), MinionTacticsMap);
@@ -218,40 +222,25 @@ namespace AmuletOfManyMinions.Core.Minions
 				TacticID = TargetSelectionTacticHandler.GetTactic(tacticName).ID;
 			} else
 			{
-				// extremely odd class of bug here where load is called multiple times, try to 
-				// make things as idempotent as possible
 				if(tacticsTag.ContainsKey("names"))
 				{
-					savedTacticsNames = tacticsTag.GetString("names").Split(',');
+					var savedTacticsNames = tacticsTag.GetString("names").Split(',');
+					for (int i = 0; i < TACTICS_GROUPS_COUNT; i++)
+					{
+						TacticIDByGroup[i] = TargetSelectionTacticHandler.GetTactic(savedTacticsNames[i]).ID;
+					}
 				}
-				if(tacticsTag.ContainsKey("minionGroups") && MinionTacticsMap.Count == 0)
+				if(tacticsTag.ContainsKey("minionGroups"))
 				{
-					buffsToLoad = tacticsTag.GetByteArray("minionGroups");
+					MemoryStream savedMinionsStream = new MemoryStream(tacticsTag.GetByteArray("minionGroups"));
+					MinionTacticsGroupMapper.ReadBuffMap(new BinaryReader(savedMinionsStream), MinionTacticsMap);
 				}
 			}
 		}
 
-		// set collections per-mod player
+		// init tactics collections per-mod player
 		private void SetInstancedCollections()
 		{
-			PlayerTacticsGroups = new PlayerTargetSelectionTactic[TACTICS_GROUPS_COUNT];
-			TacticsIDs = new byte[TACTICS_GROUPS_COUNT];
-			CurrentTacticGroup = 0;
-			MinionTacticsMap = new Dictionary<int, int>();
-
-			// this needs to be late-initialized for some reason
-			if(savedTacticsNames != null)
-			{
-				for(int i = 0; i < TACTICS_GROUPS_COUNT; i++)
-				{
-					TacticsIDs[i] = TargetSelectionTacticHandler.GetTactic(savedTacticsNames[i]).ID;
-				}
-			}
-			if(buffsToLoad != null)
-			{
-				MemoryStream savedMinionsStream = new MemoryStream(buffsToLoad);
-				MinionTacticsGroupMapper.ReadBuffMap(new BinaryReader(savedMinionsStream), MinionTacticsMap);
-			}
 			for(int i = 0; i < TACTICS_GROUPS_COUNT; i++)
 			{
 				CurrentTacticGroup = i;
@@ -313,7 +302,7 @@ namespace AmuletOfManyMinions.Core.Minions
 						SyncTimer = 0; //Stop timer from incrementing
 						if(syncTactic)
 						{
-							new TacticPacket(Player, TacticsIDs).Send();
+							new TacticPacket(Player, TacticIDByGroup).Send();
 							syncTactic = false;
 						}
 						if(syncConfig)

--- a/Core/Minions/CombatPetsQuiz/CombatPetsQuizModPlayer.cs
+++ b/Core/Minions/CombatPetsQuiz/CombatPetsQuizModPlayer.cs
@@ -34,23 +34,6 @@ namespace AmuletOfManyMinions.Core.Minions.CombatPetsQuiz
 
 		internal bool HasTakenQuiz => LastUsedTypes.Any(t => t != PersonalityType.NONE);
 
-		// TODO can't seem to get the SetStaticDefaults hook on ModSystem working, do it here instead
-		public override void SetStaticDefaults()
-		{
-			base.SetStaticDefaults();
-			QuizResult.ResultsMap = QuizResult.MakeResultsMap();
-			if(Main.dedServ)
-			{
-				return;
-			}
-			string TextureBasePath = GetType().Namespace.Replace('.', '/') + "/Portrait_";
-			foreach(var personalityType in QuizResult.ResultsMap.Keys)
-			{
-				string TexturePath = TextureBasePath + Enum.GetName(personalityType);
-				QuizResult.ResultsMap[personalityType].PortraitTexture = ModContent.Request<Texture2D>(TexturePath);
-			}
-		}
-
 		internal void StartPersonalityQuiz(int itemType)
 		{
 			IsTakingQuiz = true;

--- a/Core/Minions/CombatPetsQuiz/DefaultPetsQuizData.cs
+++ b/Core/Minions/CombatPetsQuiz/DefaultPetsQuizData.cs
@@ -1,5 +1,6 @@
 ﻿using AmuletOfManyMinions.Items.Accessories.CombatPetAccessories;
 using AmuletOfManyMinions.Items.Materials;
+using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -23,6 +24,22 @@ namespace AmuletOfManyMinions.Core.Minions.CombatPetsQuiz
 			base.Load();
 			BasicQuestions = MakeQuestions();
 			ClassSpecificQuestions = MakeClassSpecificQuestions();
+		}
+
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+			QuizResult.ResultsMap = QuizResult.MakeResultsMap();
+			if (Main.dedServ)
+			{
+				return;
+			}
+			string TextureBasePath = GetType().Namespace.Replace('.', '/') + "/Portrait_";
+			foreach (var personalityType in QuizResult.ResultsMap.Keys)
+			{
+				string TexturePath = TextureBasePath + Enum.GetName(personalityType);
+				QuizResult.ResultsMap[personalityType].PortraitTexture = ModContent.Request<Texture2D>(TexturePath);
+			}
 		}
 
 		public override void Unload()

--- a/Core/Minions/Effects/PartyHat.cs
+++ b/Core/Minions/Effects/PartyHat.cs
@@ -64,6 +64,7 @@ namespace AmuletOfManyMinions.Core.Minions.Effects
 		}
 	}
 
+	[Autoload(true, Side = ModSide.Client)]
 	public class PartyHatSystem: GlobalProjectile
 	{
 		public static Dictionary<int, PartyHatConfig> ManualHats;
@@ -75,13 +76,8 @@ namespace AmuletOfManyMinions.Core.Minions.Effects
 		public override void SetStaticDefaults()
 		{
 			// load all configurations in a single file to make backporting to 1.3 easier (ugh)
-			if(!Main.dedServ)
-			{
-				Main.instance.LoadItem(ItemID.PartyHat);
-			}
 			PostDrawHats = new Dictionary<int, PartyHatConfig>
 			{
-
 				/////////////
 				// minions //
 				/////////////
@@ -139,6 +135,7 @@ namespace AmuletOfManyMinions.Core.Minions.Effects
 
 		public static void DrawHat(Projectile projectile, PartyHatConfig config, Color lightColor)
 		{
+			Main.instance.LoadItem(ItemID.PartyHat);
 			Texture2D hatTexture = Terraria.GameContent.TextureAssets.Item[ItemID.PartyHat].Value;
 			float r = projectile.rotation;
 			SpriteEffects effects = projectile.spriteDirection * config.spriteDirection == -1 ? SpriteEffects.FlipHorizontally : 0;

--- a/Core/Minions/Effects/SolidColorTexture.cs
+++ b/Core/Minions/Effects/SolidColorTexture.cs
@@ -10,6 +10,7 @@ using Terraria.ModLoader;
 
 namespace AmuletOfManyMinions.Core.Minions.Effects
 {
+	[Autoload(true, Side = ModSide.Client)]
 	internal class SolidColorTexture : ModSystem
 	{
 		private static Dictionary<string, Texture2D> textureCache;
@@ -32,11 +33,6 @@ namespace AmuletOfManyMinions.Core.Minions.Effects
 
 		public static Texture2D GetSolidTexture(string key, Texture2D baseTexture)
 		{
-			if(Main.dedServ)
-			{
-				return default;
-			}
-
 			if(textureCache.TryGetValue(key, out var cachedTexture))
 			{
 				// don't re-process already processed textures

--- a/Core/Netcode/Packets/SyncMinionTacticsPlayerPacket.cs
+++ b/Core/Netcode/Packets/SyncMinionTacticsPlayerPacket.cs
@@ -8,8 +8,8 @@ namespace AmuletOfManyMinions.Core.Netcode.Packets
 {
 	public class SyncMinionTacticsPlayerPacket : PlayerPacket
 	{
-		readonly byte[] tacticsIds;
-		readonly byte selectedTactic;
+		readonly byte[] tacticIDByGroup;
+		readonly byte currentTacticGroup;
 		readonly Dictionary<int, int> tacticsMap;
 		readonly byte ignoreTargetReticle;
 		//mirror more fields here that have to be synced on join for MinionTacticsPlayer
@@ -18,16 +18,16 @@ namespace AmuletOfManyMinions.Core.Netcode.Packets
 
 		public SyncMinionTacticsPlayerPacket(MinionTacticsPlayer player) : base(player.Player)
 		{
-			tacticsIds = player.TacticsIDs;
-			selectedTactic = (byte)player.CurrentTacticGroup;
+			tacticIDByGroup = player.TacticIDByGroup;
+			currentTacticGroup = (byte)player.CurrentTacticGroup;
 			tacticsMap = player.MinionTacticsMap;
 			ignoreTargetReticle = player.IgnoreVanillaMinionTarget;
 		}
 
 		protected override void PostSend(BinaryWriter writer, Player player)
 		{
-			writer.Write(tacticsIds);
-			writer.Write(selectedTactic);
+			writer.Write(tacticIDByGroup);
+			writer.Write(currentTacticGroup);
 			writer.Write(ignoreTargetReticle);
 			MinionTacticsGroupMapper.WriteBuffMap(writer, tacticsMap);
 		}
@@ -35,13 +35,13 @@ namespace AmuletOfManyMinions.Core.Netcode.Packets
 		protected override void PostReceive(BinaryReader reader, int sender, Player player)
 		{
 			MinionTacticsPlayer minionTacticsPlayer = player.GetModPlayer<MinionTacticsPlayer>();
-			byte[] tacticsIds = reader.ReadBytes(MinionTacticsPlayer.TACTICS_GROUPS_COUNT);
-			byte selectedTactic = reader.ReadByte();
+			byte[] tacticIDByGroup = reader.ReadBytes(MinionTacticsPlayer.TACTICS_GROUPS_COUNT);
+			byte currentTacticGroup = reader.ReadByte();
 			byte ignoreTargetReticle = reader.ReadByte();
 			// reading rest of packet directly into dict
 			MinionTacticsGroupMapper.ReadBuffMap(reader, minionTacticsPlayer.MinionTacticsMap);
 
-			minionTacticsPlayer.SetAllTactics(tacticsIds, selectedTactic);
+			minionTacticsPlayer.SetAllTactics(tacticIDByGroup, currentTacticGroup);
 			minionTacticsPlayer.IgnoreVanillaMinionTarget = ignoreTargetReticle;
 
 		}

--- a/Core/Netcode/Packets/TacticPacket.cs
+++ b/Core/Netcode/Packets/TacticPacket.cs
@@ -7,28 +7,28 @@ namespace AmuletOfManyMinions.Core.Netcode.Packets
 {
 	public class TacticPacket : PlayerPacket
 	{
-		readonly byte[] ids;
+		readonly byte[] idByGroup;
 
 		public TacticPacket() { }
 
-		public TacticPacket(Player player, byte[] ids) : base(player)
+		public TacticPacket(Player player, byte[] idByGroup) : base(player)
 		{
-			this.ids = ids;
+			this.idByGroup = idByGroup;
 		}
 
 		protected override void PostSend(BinaryWriter writer, Player player)
 		{
-			writer.Write(ids);
+			writer.Write(idByGroup);
 		}
 
 		protected override void PostReceive(BinaryReader reader, int sender, Player player)
 		{
-			byte[] ids = reader.ReadBytes(MinionTacticsPlayer.TACTICS_GROUPS_COUNT);
+			byte[] idByGroup = reader.ReadBytes(MinionTacticsPlayer.TACTICS_GROUPS_COUNT);
 
-			player.GetModPlayer<MinionTacticsPlayer>().SetAllTactics(ids);
+			player.GetModPlayer<MinionTacticsPlayer>().SetAllTactics(idByGroup);
 			if (Main.netMode == NetmodeID.Server)
 			{
-				new TacticPacket(player, ids).Send(from: sender);
+				new TacticPacket(player, idByGroup).Send(from: sender);
 			}
 		}
 	}

--- a/Items/Consumables/CombatPetQuizItems.cs
+++ b/Items/Consumables/CombatPetQuizItems.cs
@@ -93,17 +93,9 @@ namespace AmuletOfManyMinions.Items.Consumables
 
 		public override bool CanUseItem(Player player) {
 			var quizPlayer = player.GetModPlayer<CombatPetsQuizModPlayer>();
-			if(quizPlayer.IsTakingQuiz)
-			{
-				return false;
-			}
-			if(!quizPlayer.HasTakenQuiz)
-			{
-				Main.NewText(FriendshipBowRequirement);
-				return false;
-			}
-			return true;
-		} 
+			return !quizPlayer.IsTakingQuiz;
+		}
+
 		public override void SetStaticDefaults()
 		{
 			Tooltip.SetDefault(
@@ -116,7 +108,17 @@ namespace AmuletOfManyMinions.Items.Consumables
 		{
 			if(player.whoAmI == Main.myPlayer)
 			{
-				player.GetModPlayer<CombatPetsQuizModPlayer>().StartPartnerQuiz(Type);
+				var quizPlayer = player.GetModPlayer<CombatPetsQuizModPlayer>();
+				if (!quizPlayer.HasTakenQuiz)
+				{
+					if (player.ItemAnimationJustStarted)
+					{
+						//By returning null, item will not be consumed, but item animation still runs, so this check ensures the text only shows up on first tick of use
+						Main.NewText(FriendshipBowRequirement);
+					}
+					return null;
+				}
+				quizPlayer.StartPartnerQuiz(Type);
 			}
 			return null;
 		}

--- a/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
+++ b/Projectiles/Minions/CombatPets/CombatPetBaseClasses/CombatPetLevels.cs
@@ -112,9 +112,8 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 		internal int PetDamage { get; set; }
 		
 		public int PetEmblemItem = -1;
-		public object[] PetModdedStats = new object[0];
+		public object[] PetModdedStats;
 
-		// todo this may be too many constructors, but it's a struct so I think it's ok
 		private PlayerCombatPetLevelInfo CustomInfo;
 		internal ICombatPetLevelInfo PetLevelInfo => CustomInfo.WithLevel(PetLevel);
 
@@ -164,9 +163,14 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CombatPets
 			}
 		}
 
+		public override void Initialize()
+		{
+			PetModdedStats = new object[0];
+			CustomInfo = new PlayerCombatPetLevelInfo(this);
+		}
+
 		public override void PreUpdate()
 		{
-			CustomInfo ??= new PlayerCombatPetLevelInfo(this);
 			PetDamageBonus = 0;
 			PetSpeedBonus = 0;
 			SearchRangeBonus = 0;

--- a/Projectiles/Minions/GoblinTechnomancer/GoblinTechnomancer.cs
+++ b/Projectiles/Minions/GoblinTechnomancer/GoblinTechnomancer.cs
@@ -403,13 +403,15 @@ namespace AmuletOfManyMinions.Projectiles.Minions.GoblinTechnomancer
 			Projectile.rotation = Projectile.velocity.X * 0.025f;
 		}
 
-		public override void CheckActive()
+		public override bool CheckActive()
 		{
-			base.CheckActive();
-			if(player.ownedProjectileCounts[CounterType] == 0 && animationFrame > 2)
+			if (base.CheckActive() && player.ownedProjectileCounts[CounterType] == 0 && animationFrame > 2)
 			{
 				Projectile.Kill();
+				return false;
 			}
+
+			return true;
 		}
 	}
 }

--- a/Projectiles/Minions/LilEnt/LilEnt.cs
+++ b/Projectiles/Minions/LilEnt/LilEnt.cs
@@ -154,13 +154,15 @@ namespace AmuletOfManyMinions.Projectiles.Minions.LilEnt
 			base.TargetedMovement(vectorToTargetPosition);
 		}
 
-		public override void CheckActive()
+		public override bool CheckActive()
 		{
-			base.CheckActive();
-			if(!player.GetModPlayer<MinionSpawningItemPlayer>().lilEntAccessoryEquipped)
+			if (base.CheckActive() && !player.GetModPlayer<MinionSpawningItemPlayer>().lilEntAccessoryEquipped)
 			{
 				Projectile.Kill();
+				return false;
 			}
+
+			return true;
 		}
 	}
 }

--- a/Projectiles/Minions/Minion.cs
+++ b/Projectiles/Minions/Minion.cs
@@ -63,7 +63,13 @@ namespace AmuletOfManyMinions.Projectiles.Minions
 		public override void AI()
 		{
 			player = Main.player[Projectile.owner];
-			CheckActive();
+
+			if (!CheckActive())
+			{
+				//Projectile despawned, don't continue with AI
+				return;
+			}
+
 			if (!Spawned)
 			{
 				Spawned = true;
@@ -78,7 +84,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions
 
 		}
 
-		public virtual void CheckActive()
+		/// <summary>
+		/// Returns false if the projectile was manually despawned
+		/// </summary>
+		public virtual bool CheckActive()
 		{
 			// This is the "active check", makes sure the minion is alive while the player is alive, and despawns if not
 			if (player.dead || !player.active)
@@ -93,7 +102,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions
 			else if (Main.projPet[Projectile.type])
 			{
 				Projectile.Kill(); // pets don't die naturally for some reason
+				return false;
 			}
+
+			return true;
 		}
 
 		/// <summary>

--- a/Projectiles/Minions/Necromancer/Necromancer.cs
+++ b/Projectiles/Minions/Necromancer/Necromancer.cs
@@ -363,13 +363,15 @@ namespace AmuletOfManyMinions.Projectiles.Minions.Necromancer
 				Projectile.spriteDirection = Projectile.velocity.X > 0 ? 1 : -1;
 			}
 		}
-		public override void CheckActive()
+		public override bool CheckActive()
 		{
-			base.CheckActive();
-			if(player.ownedProjectileCounts[CounterType] == 0 && animationFrame > 2)
+			if (base.CheckActive() && player.ownedProjectileCounts[CounterType] == 0 && animationFrame > 2)
 			{
 				Projectile.Kill();
+				return false;
 			}
+
+			return true;
 		}
 	}
 

--- a/Projectiles/Minions/VanillaClones/JourneysEnd/EnchantedDagger.cs
+++ b/Projectiles/Minions/VanillaClones/JourneysEnd/EnchantedDagger.cs
@@ -71,7 +71,10 @@ namespace AmuletOfManyMinions.Projectiles.Minions.VanillaClones.JourneysEnd
 		{
 			base.OnSpawn();
 			// run this as late as possible, hope to avoid issues with asset loading
-			solidTexture = SolidColorTexture.GetSolidTexture(Type);
+			if (!Main.dedServ)
+			{
+				solidTexture = SolidColorTexture.GetSolidTexture(Type);
+			}
 		}
 
 		public override Vector2 IdleBehavior()

--- a/Projectiles/Minions/VanillaClones/JourneysEnd/Flinx.cs
+++ b/Projectiles/Minions/VanillaClones/JourneysEnd/Flinx.cs
@@ -66,14 +66,15 @@ namespace AmuletOfManyMinions.Projectiles.Minions.VanillaClones.JourneysEnd
 			Projectile.minionSlots = 0;
 		}
 
-		public override void CheckActive()
+		public override bool CheckActive()
 		{
-			base.CheckActive();
-			if(!player.GetModPlayer<MinionSpawningItemPlayer>().flinxArmorSetEquipped)
+			if (base.CheckActive() && !player.GetModPlayer<MinionSpawningItemPlayer>().flinxArmorSetEquipped)
 			{
 				Projectile.Kill();
+				return false;
 			}
-		}
 
+			return true;
+		}
 	}
 }

--- a/Projectiles/NonMinionSummons/TransientMinion.cs
+++ b/Projectiles/NonMinionSummons/TransientMinion.cs
@@ -55,9 +55,10 @@ namespace AmuletOfManyMinions.Projectiles.NonMinionSummons
 			return;
 		}
 
-		public override void CheckActive()
+		public override bool CheckActive()
 		{
 			// no-op
+			return true;
 		}
 	}
 }

--- a/Projectiles/Squires/EmpressSquire/EmpressSquire.cs
+++ b/Projectiles/Squires/EmpressSquire/EmpressSquire.cs
@@ -137,8 +137,11 @@ namespace AmuletOfManyMinions.Projectiles.Squires.EmpressSquire
 		{
 			base.OnSpawn();
 			// run this as late as possible, hope to avoid issues with asset loading
-			solidTexture = SolidColorTexture.GetSolidTexture(Type);
-			solidWeaponTexture = SolidColorTexture.GetSolidTexture("EmpressWeapon", WeaponTexture.Value);
+			if (!Main.dedServ)
+			{
+				solidTexture = SolidColorTexture.GetSolidTexture(Type);
+				solidWeaponTexture = SolidColorTexture.GetSolidTexture("EmpressWeapon", WeaponTexture.Value);
+			}
 		}
 
 		public override void SpecialTargetedMovement(Vector2 vectorToTargetPosition)

--- a/UI/CombatPetsQuizUI/CombatPetsQuizUIPanel.cs
+++ b/UI/CombatPetsQuizUI/CombatPetsQuizUIPanel.cs
@@ -102,6 +102,11 @@ namespace AmuletOfManyMinions.UI.CombatPetsQuizUI
 					lastDisplayedText = currentText;
 				}
 				int charactersToDisplay = Math.Min(currentText.Length, 2 * (int)(Main.GameUpdateCount - textSwitchTime));
+				if (charactersToDisplay < 0)
+				{
+					//Fallback when in MP Main.GameUpdateCount behaves weirdly, causing the calculated index to be negative
+					charactersToDisplay = currentText.Length;
+				}
 				questionPanel.TextLines = TextFont.CreateWrappedText(
 					currentText.Substring(0, charactersToDisplay), MaxTextboxWidth - 4 * MarginSize).Split('\n');
 				if(charactersToDisplay == currentText.Length && ModPlayer.CurrentQuiz.CurrentState == QuizState.QUIZ)

--- a/UI/TacticsUI/TacticsGroupButton.cs
+++ b/UI/TacticsUI/TacticsGroupButton.cs
@@ -60,7 +60,7 @@ namespace AmuletOfManyMinions.UI.TacticsUI
 			base.DrawSelf(spriteBatch);
 			// draw a little icon in the bottem left corner the current tactic for the given group
 			MinionTacticsPlayer tacticsPlayer = Main.player[Main.myPlayer].GetModPlayer<MinionTacticsPlayer>();
-			byte tacticsId = tacticsPlayer.TacticsIDs[index];
+			byte tacticsId = tacticsPlayer.TacticIDByGroup[index];
 			Texture2D tacticSmallTexture = TargetSelectionTacticHandler.SmallTextures[tacticsId].Value;
 			CalculatedStyle dimensions = GetDimensions();
 			float scale = 0.75f;

--- a/UI/UserInterfaces.cs
+++ b/UI/UserInterfaces.cs
@@ -17,6 +17,7 @@ namespace AmuletOfManyMinions.UI
 	/// <summary>
 	/// Contains all UIs, and manages boilerplate drawing/updating
 	/// </summary>
+	[Autoload(true, Side = ModSide.Client)]
 	public class UserInterfaces : ModSystem
 	{
 		internal static UserInterface tacticsInterface;
@@ -28,26 +29,23 @@ namespace AmuletOfManyMinions.UI
 
 		public override void OnModLoad()
 		{
-			if (!Main.dedServ)
-			{
-				tacticsInterface = new UserInterface();
+			tacticsInterface = new UserInterface();
 
-				tacticsUI = new TacticsUIMain();
-				buffClickCapture = new BuffRowClickCapture();
-				quizUI = new CombatPetsQuizUIMain();
-				tacticsUI.Activate();
-				buffClickCapture.Activate();
-				quizUI.Activate();
+			tacticsUI = new TacticsUIMain();
+			buffClickCapture = new BuffRowClickCapture();
+			quizUI = new CombatPetsQuizUIMain();
+			tacticsUI.Activate();
+			buffClickCapture.Activate();
+			quizUI.Activate();
 
-				UIState state = new UIState();
-				state.Append(quizUI);
-				state.Append(buffClickCapture);
-				// tacticsUI should take priority over buffClickCapture in the case that
-				// they're both active
-				state.Append(tacticsUI);
+			UIState state = new UIState();
+			state.Append(quizUI);
+			state.Append(buffClickCapture);
+			// tacticsUI should take priority over buffClickCapture in the case that
+			// they're both active
+			state.Append(tacticsUI);
 
-				tacticsInterface.SetState(state);
-			}
+			tacticsInterface.SetState(state);
 		}
 
 		public override void Unload()


### PR DESCRIPTION
* Fix minions still running AI for one tick after player despawns, causing exceptions
    * Change CheckActive to a bool return indicating if it despawned or not, and halting AI code execution if it despawned
* Fix bow of friendship usage in multiplayer causing server and client exceptions
    * Main.NewText was running on the server
    * Sometimes, Main.GameUpdateCount acted weird on clients causing the substring end index to be negative
* Move some code back into ModSystem as it's now fixed on tmls side
* Init reference fields in LeveledCombatPetModPlayer correctly (gameplay: set starting tactic correctly)
    * Utilize Initialize hook properly, get rid of "workaround"-ish code related to previous implementation
    * Starting tactic is now correctly set to the top-left one (it was defaulting to the one that has ID of 0, which happened to be the bottom-right one)
    * Rename TacticsID to TacticIDByGroup to better represent what it is
* Load certain classes only on client
    * Avoids some !Main.dedServ checks, less classes to keep track of for the server