### PR TITLE
Reimplemented Summoner's Shine explicit changes

### DIFF
--- a/CrossModClient/SummonersShine/General.cs
+++ b/CrossModClient/SummonersShine/General.cs
@@ -20,7 +20,7 @@ namespace AmuletOfManyMinions.CrossModClient.SummonersShine
 		internal static bool SummonersShineDisabled(out Mod summonersShine)
 		{
 			Mod rvMod = null;
-			bool rv = !CrossMod.SummonersShineLoaded || ServerConfig.Instance.DisableSummonersShineAI || !ModLoader.TryGetMod("SummonersShine", out rvMod);
+			bool rv = !CrossMod.SummonersShineLoaded || !ModLoader.TryGetMod("SummonersShine", out rvMod) || ServerConfig.Instance.DisableSummonersShineAI;
 			summonersShine = rvMod;
 			return rv;
 		}

--- a/CrossModClient/SummonersShine/General.cs
+++ b/CrossModClient/SummonersShine/General.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria.ModLoader;
+
+namespace AmuletOfManyMinions.CrossModClient.SummonersShine
+{
+	internal static class General
+	{
+		const int CHANGECONFIG = 0;
+		const int COUNTASMINION = 5;
+
+
+		const int CHANGEMINIONSTATICS = 1;
+		const int CHANGELERPTYPE = 23;
+		const int STEPPED = 1;
+
+		internal static bool SummonersShineDisabled(out Mod summonersShine)
+		{
+			Mod rvMod = null;
+			bool rv = !CrossMod.SummonersShineLoaded || ServerConfig.Instance.DisableSummonersShineAI || !ModLoader.TryGetMod("SummonersShine", out rvMod);
+			summonersShine = rvMod;
+			return rv;
+		}
+		internal static void ApplyChanges_COUNTASMINION(int ProjType)
+		{
+			if (SummonersShineDisabled(out Mod summonersShine))
+				return;
+			summonersShine.Call(CHANGECONFIG, COUNTASMINION, ProjType);
+		}
+
+		internal static void ApplyChanges_STEPPED(int ProjType)
+		{
+			if (SummonersShineDisabled(out Mod summonersShine))
+				return;
+			summonersShine.Call(CHANGEMINIONSTATICS, ProjType, CHANGELERPTYPE, STEPPED);
+		}
+	}
+}

--- a/Projectiles/Minions/CharredChimera/CharredChimera.cs
+++ b/Projectiles/Minions/CharredChimera/CharredChimera.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Terraria;
+using Terraria.ModLoader;
 using Terraria.ID;
 using static Terraria.ModLoader.ModContent;
 
@@ -72,6 +73,20 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CharredChimera
 			ProjectileID.Sets.CultistIsResistantTo[Projectile.type] = true;
 			ProjectileID.Sets.MinionShot[Projectile.type] = true;
 		}
+		
+		public override void ApplyCrossModChanges()
+		{
+			base.ApplyCrossModChanges();
+			const int CHANGECONFIG = 0;
+			const int COUNTASMINION = 5;
+			if (CrossMod.SummonersShineLoaded && !ServerConfig.Instance.DisableSummonersShineAI && ModLoader.TryGetMod("SummonersShine", out Mod summonersShine))
+			{
+				summonersShine.Call(CHANGECONFIG, COUNTASMINION, Projectile.type);
+				return;
+			}
+			return;
+		}
+		
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/Minions/CharredChimera/CharredChimera.cs
+++ b/Projectiles/Minions/CharredChimera/CharredChimera.cs
@@ -77,14 +77,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.CharredChimera
 		public override void ApplyCrossModChanges()
 		{
 			base.ApplyCrossModChanges();
-			const int CHANGECONFIG = 0;
-			const int COUNTASMINION = 5;
-			if (CrossMod.SummonersShineLoaded && !ServerConfig.Instance.DisableSummonersShineAI && ModLoader.TryGetMod("SummonersShine", out Mod summonersShine))
-			{
-				summonersShine.Call(CHANGECONFIG, COUNTASMINION, Projectile.type);
-				return;
-			}
-			return;
+			CrossModClient.SummonersShine.General.ApplyChanges_COUNTASMINION(Type);
 		}
 		
 		public override void SetDefaults()

--- a/Projectiles/Minions/TerrarianEnt/LandChunkProjectile.cs
+++ b/Projectiles/Minions/TerrarianEnt/LandChunkProjectile.cs
@@ -62,14 +62,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.TerrarianEnt
 		public override void ApplyCrossModChanges()
 		{
 			base.ApplyCrossModChanges();
-			const int CHANGECONFIG = 0;
-			const int COUNTASMINION = 5;
-			if (CrossMod.SummonersShineLoaded && !ServerConfig.Instance.DisableSummonersShineAI && ModLoader.TryGetMod("SummonersShine", out Mod summonersShine))
-			{
-				summonersShine.Call(CHANGECONFIG, COUNTASMINION, Projectile.type);
-				return;
-			}
-			return;
+			CrossModClient.SummonersShine.General.ApplyChanges_COUNTASMINION(Type);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/Minions/TerrarianEnt/LandChunkProjectile.cs
+++ b/Projectiles/Minions/TerrarianEnt/LandChunkProjectile.cs
@@ -58,6 +58,19 @@ namespace AmuletOfManyMinions.Projectiles.Minions.TerrarianEnt
 			ProjectileID.Sets.MinionSacrificable[Projectile.type] = false;
 			Main.projFrames[Projectile.type] = 2;
 		}
+		
+		public override void ApplyCrossModChanges()
+		{
+			base.ApplyCrossModChanges();
+			const int CHANGECONFIG = 0;
+			const int COUNTASMINION = 5;
+			if (CrossMod.SummonersShineLoaded && !ServerConfig.Instance.DisableSummonersShineAI && ModLoader.TryGetMod("SummonersShine", out Mod summonersShine))
+			{
+				summonersShine.Call(CHANGECONFIG, COUNTASMINION, Projectile.type);
+				return;
+			}
+			return;
+		}
 
 		public override void SetDefaults()
 		{

--- a/Projectiles/Minions/TerrarianEnt/TerrarianEnt.cs
+++ b/Projectiles/Minions/TerrarianEnt/TerrarianEnt.cs
@@ -88,15 +88,7 @@ namespace AmuletOfManyMinions.Projectiles.Minions.TerrarianEnt
 		public override void ApplyCrossModChanges()
 		{
 			base.ApplyCrossModChanges();
-			const int CHANGEMINIONSTATICS = 1;
-			const int CHANGELERPTYPE = 23;
-			const int STEPPED = 1;
-			if (CrossMod.SummonersShineLoaded && !ServerConfig.Instance.DisableSummonersShineAI && ModLoader.TryGetMod("SummonersShine", out Mod summonersShine))
-			{
-				summonersShine.Call(CHANGEMINIONSTATICS, Projectile.type, CHANGELERPTYPE, STEPPED);
-				return;
-			}
-			return;
+			CrossModClient.SummonersShine.General.ApplyChanges_STEPPED(Type);
 		}
 
 		public sealed override void SetDefaults()

--- a/Projectiles/Minions/TerrarianEnt/TerrarianEnt.cs
+++ b/Projectiles/Minions/TerrarianEnt/TerrarianEnt.cs
@@ -84,6 +84,20 @@ namespace AmuletOfManyMinions.Projectiles.Minions.TerrarianEnt
 			Main.projFrames[Projectile.type] = 1;
 			IdleLocationSets.trailingInAir.Add(Projectile.type);
 		}
+		
+		public override void ApplyCrossModChanges()
+		{
+			base.ApplyCrossModChanges();
+			const int CHANGEMINIONSTATICS = 1;
+			const int CHANGELERPTYPE = 23;
+			const int STEPPED = 1;
+			if (CrossMod.SummonersShineLoaded && !ServerConfig.Instance.DisableSummonersShineAI && ModLoader.TryGetMod("SummonersShine", out Mod summonersShine))
+			{
+				summonersShine.Call(CHANGEMINIONSTATICS, Projectile.type, CHANGELERPTYPE, STEPPED);
+				return;
+			}
+			return;
+		}
 
 		public sealed override void SetDefaults()
 		{


### PR DESCRIPTION
Charred Chimera Heads are now affected by attack speed
Land Chunk Projectile grow time is now affected by attack speed
Terrarian Ent's animation and velocity is no longer LERP'd by attack speed