### PR TITLE
[Bugfix] Non-Standard Terrarian Ent Speed can cause issues with tree sprite

### DIFF
--- a/Projectiles/Minions/TerrarianEnt/CompositeSpriteBatchDrawer.cs
+++ b/Projectiles/Minions/TerrarianEnt/CompositeSpriteBatchDrawer.cs
@@ -210,6 +210,9 @@ namespace AmuletOfManyMinions.Projectiles.Minions.TerrarianEnt
 			int maxHeight = TileTop + treeTileSize / 2 * trunkHeight;
 			trunkHeightOffset = Math.Min(maxHeight, heightPerFrame * trunkAnimFrame - treeTileSize);
 
+			if (Main.dedServ)
+				return;
+
 			// bottom of tree configs
 			if (trunkTileRowToDraw == trunkHeight - 1 && rootsConfig != 1)
 			{

--- a/Projectiles/Minions/TerrarianEnt/CompositeSpriteBatchDrawer.cs
+++ b/Projectiles/Minions/TerrarianEnt/CompositeSpriteBatchDrawer.cs
@@ -1,4 +1,4 @@
-﻿using AmuletOfManyMinions.Projectiles.Minions.MinonBaseClasses;
+using AmuletOfManyMinions.Projectiles.Minions.MinonBaseClasses;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using ReLogic.Content;
@@ -209,6 +209,18 @@ namespace AmuletOfManyMinions.Projectiles.Minions.TerrarianEnt
 			trunkTileRowToDraw = (int)Math.Min(trunkHeight-1, trunkAnimFrame * heightPerFrame / (float)treeTileSize);
 			int maxHeight = TileTop + treeTileSize / 2 * trunkHeight;
 			trunkHeightOffset = Math.Min(maxHeight, heightPerFrame * trunkAnimFrame - treeTileSize);
+
+			// bottom of tree configs
+			if (trunkTileRowToDraw == trunkHeight - 1 && rootsConfig != 1)
+			{
+				// tile where roots connect
+				tiles[0, trunkTileRowToDraw, 1] = ((byte)(rootsConfig == 0 ? 0 : 3), (byte)(6 + trunkTileRowToDraw % 3));
+			}
+			else
+			{
+				// rest of trunk
+				tiles[0, trunkTileRowToDraw, 1] = TrunkTileForLocation(trunkTileRowToDraw);
+			}
 		}
 
 		public TreeDrawer(
@@ -253,16 +265,6 @@ namespace AmuletOfManyMinions.Projectiles.Minions.TerrarianEnt
 			if(trunkAnimFrame < 0)
 			{
 				return;
-			}
-			// bottom of tree configs
-			if (trunkTileRowToDraw == trunkHeight - 1 && rootsConfig != 1)
-			{
-				// tile where roots connect
-				tiles[0, trunkTileRowToDraw, 1] = ((byte)(rootsConfig == 0 ? 0 : 3), (byte)(6 + trunkTileRowToDraw % 3));
-			} else
-			{
-				// rest of trunk
-				tiles[0, trunkTileRowToDraw, 1] = TrunkTileForLocation(trunkTileRowToDraw);
 			}
 			helper.AddTileSpritesToBatch(woodTexture, 0, tiles, Vector2.UnitY * -trunkHeightOffset, tileSize: treeTileSize);
 		}

--- a/Projectiles/Minions/TerrarianEnt/TerrarianEnt.cs
+++ b/Projectiles/Minions/TerrarianEnt/TerrarianEnt.cs
@@ -1,4 +1,4 @@
-﻿using AmuletOfManyMinions.Projectiles.Minions.Acorn;
+using AmuletOfManyMinions.Projectiles.Minions.Acorn;
 using AmuletOfManyMinions.Projectiles.Minions.MinonBaseClasses;
 using AmuletOfManyMinions.Projectiles.NonMinionSummons;
 using Microsoft.Xna.Framework;
@@ -83,12 +83,6 @@ namespace AmuletOfManyMinions.Projectiles.Minions.TerrarianEnt
 			// Sets the amount of frames this minion has on its spritesheet
 			Main.projFrames[Projectile.type] = 1;
 			IdleLocationSets.trailingInAir.Add(Projectile.type);
-		}
-		
-		public override void ApplyCrossModChanges()
-		{
-			base.ApplyCrossModChanges();
-			CrossModClient.SummonersShine.General.ApplyChanges_STEPPED(Type);
 		}
 
 		public sealed override void SetDefaults()


### PR DESCRIPTION
Currently, Terrarian Ent will fail to draw some tile segments if the minion speed is too fast. This is because the tiles are erroneously filled in Draw(), which is called 60 times a frame, rather than Update().

On a side note, this will also prevent the tile filling function from running if the game is paused.